### PR TITLE
build: build with baseruby that is compiled from the same source

### DIFF
--- a/builders/wasm32-unknown-emscripten/Dockerfile
+++ b/builders/wasm32-unknown-emscripten/Dockerfile
@@ -2,7 +2,7 @@ FROM emscripten/emsdk:2.0.13
 
 RUN set -eux; \
   apt-get update; \
-  apt-get install ruby bison make autoconf git curl -y; \
+  apt-get install ruby bison make autoconf git curl build-essential libyaml-dev -y; \
   curl -fsSL https://deb.nodesource.com/setup_16.x | bash -; \
   apt-get install nodejs -y; \
   apt-get clean; \

--- a/builders/wasm32-unknown-wasi/Dockerfile
+++ b/builders/wasm32-unknown-wasi/Dockerfile
@@ -17,7 +17,7 @@ ENV WASI_SDK_PATH="/opt/wasi-sdk"
 
 RUN set -eux; \
   apt-get update; \
-  apt-get install ruby bison make autoconf git curl -y; \
+  apt-get install ruby bison make autoconf git curl build-essential libyaml-dev -y; \
   curl -fsSL https://deb.nodesource.com/setup_16.x | bash -; \
   apt-get install nodejs -y; \
   apt-get clean; \


### PR DESCRIPTION
The system installed Ruby (especially Debian) can override
`Gem.default_dir` to lookup gems installed by the OS package managers.
And `rbinstall.rb` respects `Gem.default_dir` to select install
directory of gems under `DESTDIR`. So it installs gems in
`DESTDIR/var/lib/gems/3.2.0+1` where the Debian's `operating_system.rb`
specifies.
However, `Gem.default_dir` is not overridden at runtime on Wasm, so it
lookups `DESTDIR/usr/local/lib/ruby/gems/3.2.0+1` instead. The mismatch
of `default_dir` between install-time and runtime causes the failure of
gem lookup.
To fix this mismatch, stop using system packaged ruby to avoid loading
`operating_system.rb`, and use self-built ruby, which doesn't patch
`Gem.default_dir`.
This change also makes our build compatible with cross-compilation
prerequisite:
https://bugs.ruby-lang.org/projects/ruby/wiki/DeveloperHowto#prerequisite