### PR TITLE
Update Binaryen version to 108

### DIFF
--- a/builders/wasm32-unknown-wasi/Dockerfile
+++ b/builders/wasm32-unknown-wasi/Dockerfile
@@ -9,7 +9,7 @@ FROM debian:buster
 
 ARG WASI_SDK_VERSION_MAJOR=14
 ARG WASI_SDK_VERSION_MINOR=0
-ARG BINARYEN_VERSION=91
+ARG BINARYEN_VERSION=108
 ARG WASI_VFS_VERSION=0.1.1
 ARG WASI_PRESET_ARGS_VERSION=0.1.1
 
@@ -31,12 +31,12 @@ RUN set -eux pipefail; \
 
 ENV BINARYEN_DIR="/opt/binaryen"
 RUN set -eux pipefail; \
-  binaryen_tarball="binaryen-version_${BINARYEN_VERSION}-x86-linux.tar.gz"; \
+  binaryen_tarball="binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz"; \
   binaryen_url="https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/${binaryen_tarball}"; \
   curl -L "$binaryen_url" | tar xfz -; \
   ln -fs /binaryen-version_${BINARYEN_VERSION} /opt/binaryen;
 
-ENV PATH="$BINARYEN_DIR:$PATH"
+ENV PATH="$BINARYEN_DIR/bin:$PATH"
 
 ENV LIB_WASI_VFS_A="/opt/wasi-vfs/lib/libwasi_vfs.a"
 RUN set -eux pipefail; \


### PR DESCRIPTION
We used the old version 91 to avoid insufficient stack size issue in
Asyncify, but the latest version has fixed it.
https://github.com/WebAssembly/binaryen/issues/4401