### PR TITLE
Omit ruby.debug.wasm in npm package to reduce size

### DIFF
--- a/packages/npm-packages/ruby-head-wasm-wasi/README.md
+++ b/packages/npm-packages/ruby-head-wasm-wasi/README.md
@@ -28,7 +28,7 @@ const main = async () => {
   const binary = await fs.readFile(
     //  Tips: Replace the binary with debug info if you want symbolicated stack trace.
     //  (only nightly release for now)
-    //  "./node_modules/ruby-head-wasm-wasi/dist/ruby.debug.wasm"
+    //  "./node_modules/ruby-head-wasm-wasi/dist/ruby.debug+stdlib.wasm"
     "./node_modules/ruby-head-wasm-wasi/dist/ruby.wasm"
   );
   const module = await WebAssembly.compile(binary);
@@ -64,7 +64,7 @@ See [the example project](https://github.com/ruby/ruby.wasm/tree/main/packages/n
       const response = await fetch(
         //      Tips: Replace the binary with debug info if you want symbolicated stack trace.
         //      (only nightly release for now)
-        //      "https://cdn.jsdelivr.net/npm/ruby-head-wasm-wasi@latest/dist/ruby.debug.wasm"
+        //      "https://cdn.jsdelivr.net/npm/ruby-head-wasm-wasi@next/dist/ruby.debug+stdlib.wasm"
         "https://cdn.jsdelivr.net/npm/ruby-head-wasm-wasi@latest/dist/ruby.wasm"
       );
       const buffer = await response.arrayBuffer();

--- a/packages/npm-packages/ruby-wasm-wasi/build-package.sh
+++ b/packages/npm-packages/ruby-wasm-wasi/build-package.sh
@@ -29,7 +29,6 @@ wit-bindgen js \
 )
 
 wasm-opt --strip-debug "$ruby_root/usr/local/bin/ruby" -o "$dist_dir/ruby.wasm"
-cp "$ruby_root/usr/local/bin/ruby" "$dist_dir/ruby.debug.wasm"
 
 # Build +stdlib versions (removing files that are not used in normal use cases)
 workdir="$(mktemp -d)"
@@ -38,7 +37,7 @@ rm -rf $workdir/ruby-root/usr/local/include
 rm -f $workdir/ruby-root/usr/local/lib/libruby-static.a
 rm -f $workdir/ruby-root/usr/local/bin/ruby
 wasi-vfs pack "$dist_dir/ruby.wasm" --mapdir /usr::$workdir/ruby-root/usr -o "$dist_dir/ruby+stdlib.wasm"
-wasi-vfs pack "$dist_dir/ruby.debug.wasm" --mapdir /usr::$workdir/ruby-root/usr -o "$dist_dir/ruby.debug+stdlib.wasm"
+wasi-vfs pack "$ruby_root/usr/local/bin/ruby" --mapdir /usr::$workdir/ruby-root/usr -o "$dist_dir/ruby.debug+stdlib.wasm"
 
 
 mkdir "$dist_dir/bindgen"

--- a/packages/npm-packages/ruby-wasm-wasi/test/package.test.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/test/package.test.ts
@@ -31,7 +31,6 @@ describe("Packaging validation", () => {
 
   test.each([
     { file: "ruby+stdlib.wasm", stdlib: true },
-    { file: "ruby.debug.wasm", stdlib: false },
     { file: "ruby.debug+stdlib.wasm", stdlib: true },
   ])("Load all variants", async ({ file, stdlib }) => {
     const binary = await fs.readFile(path.join(__dirname, `./../dist/${file}`));


### PR DESCRIPTION
Since jsdelivr.com rejects packages larger than 100MB for distribution,
so we need to care about the total package size even though individual
file size is under the limit.
Therefore, omit ruby.debug.wasm since ruby.debug+stdlib.wasm can play a
super-set role of it.