### PR TITLE
Inspect JS value by `String(v)` instead of `v.toString`

### DIFF
--- a/packages/npm-packages/ruby-wasm-wasi/src/index.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/index.ts
@@ -102,7 +102,9 @@ export class RubyVM {
           return new RbValue(abiValue, this, this.privateObject());
         },
         jsValueToString: (value) => {
-          return value.toString();
+          // According to the [spec](https://tc39.es/ecma262/multipage/text-processing.html#sec-string-constructor-string-value)
+          // `String(value)` always returns a string.
+          return String(value);
         },
         exportJsValueToHost: (value) => {
           // See `JsValueExporter` for the reason why we need to do this

--- a/packages/npm-packages/ruby-wasm-wasi/test/js_from_rb.test.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/test/js_from_rb.test.ts
@@ -133,6 +133,9 @@ describe("Manipulation of JS from Ruby", () => {
   test.each([
     { expr: `JS.global`, expected: "[object Object]" },
     { expr: `1.to_js`, expected: "1" },
+    { expr: `JS.eval("return null")`, expected: "null" },
+    { expr: `JS.eval("return undefined")`, expected: "undefined" },
+    { expr: `JS.eval("return Symbol('sym')")`, expected: "Symbol(sym)" },
     { expr: `JS.eval("return {}")`, expected: "[object Object]" },
     {
       expr: `JS.eval("class X {}; return new X()")`,


### PR DESCRIPTION
To handle null, undefined properly. Without this change, they would
cause: `TypeError: Cannot read properties of null (reading 'toString')`