### PR TITLE
Use `target.[[Get]](key)` directly instead of `Reflect.get`

### DIFF
--- a/packages/npm-packages/ruby-wasm-wasi/src/index.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/index.ts
@@ -139,7 +139,7 @@ export class RubyVM {
           throw new Error("Function not implemented.");
         },
         reflectGet: function (target, propertyKey) {
-          return Reflect.get(target, propertyKey);
+          return target[propertyKey];
         },
         reflectGetOwnPropertyDescriptor: function (
           target,


### PR DESCRIPTION
Since it denies non-objects like strings according to the spec
https://262.ecma-international.org/11.0/#sec-reflect.get

Also it throws just `TypeError: Reflect.get called on non-object` while
`target.[[Get]]` reports `TypeError: Cannot read properties of null (reading X)`
when reading non-object properties