### PR TITLE
Implement Proc#to_js and add ability to pass blocks to JS::Object#call

### DIFF
--- a/ext/js/bindgen/rb-js-abi-host.wit
+++ b/ext/js/bindgen/rb-js-abi-host.wit
@@ -7,6 +7,7 @@ global-this: function() -> js-abi-value
 int-to-js-number: function(value: s32) -> js-abi-value
 string-to-js-string: function(value: string) -> js-abi-value
 bool-to-js-bool: function(value: bool) -> js-abi-value
+proc-to-js-function: function(value: u32) -> js-abi-value
 rb-object-to-js-rb-value: function(raw-rb-abi-value: u32) -> js-abi-value
 
 js-value-to-string: function(value: js-abi-value) -> string

--- a/ext/js/js-core.c
+++ b/ext/js/js-core.c
@@ -15,6 +15,7 @@ extern VALUE rb_cInteger;
 extern VALUE rb_cString;
 extern VALUE rb_cTrueClass;
 extern VALUE rb_cFalseClass;
+extern VALUE rb_cProc;
 
 // from js/js-core.c
 void rb_abi_lend_object(VALUE obj);
@@ -365,6 +366,10 @@ static VALUE _rb_js_false_to_js(VALUE obj) {
   return jsvalue_s_new(rb_js_abi_host_bool_to_js_bool(false));
 }
 
+static VALUE _rb_js_proc_to_js(VALUE obj) {
+  return jsvalue_s_new(rb_js_abi_host_proc_to_js_function((uint32_t) obj));
+}
+
 /*
  * JavaScript interoperations module
  */
@@ -395,4 +400,5 @@ void Init_js() {
   rb_define_method(rb_cString, "to_js", _rb_js_string_to_js, 0);
   rb_define_method(rb_cTrueClass, "to_js", _rb_js_true_to_js, 0);
   rb_define_method(rb_cFalseClass, "to_js", _rb_js_false_to_js, 0);
+  rb_define_method(rb_cProc, "to_js", _rb_js_proc_to_js, 0);
 }

--- a/ext/js/js-core.c
+++ b/ext/js/js-core.c
@@ -376,6 +376,12 @@ static VALUE _rb_js_false_to_js(VALUE obj) {
   return jsvalue_s_new(rb_js_abi_host_bool_to_js_bool(false));
 }
 
+/*
+ * call-seq:
+ *   to_js -> JS::Object
+ *
+ *  Returns +self+ as a JS::Object.
+ */
 static VALUE _rb_js_proc_to_js(VALUE obj) {
   rb_abi_lend_object(obj);
   return jsvalue_s_new(rb_js_abi_host_proc_to_js_function((uint32_t) obj));

--- a/ext/js/js-core.c
+++ b/ext/js/js-core.c
@@ -247,8 +247,12 @@ static VALUE _rb_js_obj_call(int argc, VALUE *argv, VALUE obj) {
   struct jsvalue *abi_method = check_jsvalue(method);
 
   rb_js_abi_host_list_js_abi_value_t abi_args;
-  abi_args.ptr = ALLOCA_N(rb_js_abi_host_js_abi_value_t, argc - 1);
-  abi_args.len = argc - 1;
+  int function_arguments_count = argc;
+  if(!rb_block_given_p())
+    function_arguments_count -= 1;
+
+  abi_args.ptr = ALLOCA_N(rb_js_abi_host_js_abi_value_t, function_arguments_count);
+  abi_args.len = function_arguments_count;
   for (int i = 1; i < argc; i++) {
     VALUE arg = _rb_js_try_convert(rb_mJS, argv[i]);
     if (arg == Qnil) {
@@ -257,6 +261,12 @@ static VALUE _rb_js_obj_call(int argc, VALUE *argv, VALUE obj) {
     }
     abi_args.ptr[i - 1] = check_jsvalue(arg)->abi;
   }
+
+  if(rb_block_given_p()) {
+    VALUE proc = rb_block_proc();
+    abi_args.ptr[function_arguments_count - 1] = check_jsvalue(_rb_js_try_convert(rb_mJS, proc))->abi;
+  }
+
   return jsvalue_s_new(
       rb_js_abi_host_reflect_apply(abi_method->abi, p->abi, &abi_args));
 }

--- a/ext/js/js-core.c
+++ b/ext/js/js-core.c
@@ -377,6 +377,7 @@ static VALUE _rb_js_false_to_js(VALUE obj) {
 }
 
 static VALUE _rb_js_proc_to_js(VALUE obj) {
+  rb_abi_lend_object(obj);
   return jsvalue_s_new(rb_js_abi_host_proc_to_js_function((uint32_t) obj));
 }
 

--- a/packages/npm-packages/ruby-wasm-wasi/src/index.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/index.ts
@@ -221,12 +221,7 @@ export class RubyVM {
 
   private rbValueofPointer(pointer: number): RbValue {
     const abiValue = new (RbAbi.RbAbiValue as any)(pointer, this.guest);
-    const rbValue = new RbValue(abiValue, this, this.privateObject());
-    
-    // Without doing this there is a chance that rbValue is being GC-collected.
-    // By using Object#itself, the witapi-Extension knows about this object and keeps
-    // a reference to it, which prevents GC-collection.
-    return rbValue.call('itself');
+    return new RbValue(abiValue, this, this.privateObject());
   }
 }
 

--- a/packages/npm-packages/ruby-wasm-wasi/test/js_from_rb.test.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/test/js_from_rb.test.ts
@@ -122,6 +122,15 @@ describe("Manipulation of JS from Ruby", () => {
       expr: `JS.global[:Math].call(:min, JS.eval("return 1"), JS.eval("return 2"))`,
       result: 1,
     },
+    {
+      expr: `
+        function_to_call = JS.eval('return { a: (callback) => { callback(1) } }')
+        b = nil
+        function_to_call.call(:a, Proc.new { |a| b = a })
+        b
+      `,
+      result: 1
+    }
   ])(`JS::Object#call (%s)`, async (props) => {
     const vm = await initRubyVM();
     const result = vm.eval(`

--- a/packages/npm-packages/ruby-wasm-wasi/test/js_from_rb.test.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/test/js_from_rb.test.ts
@@ -130,6 +130,15 @@ describe("Manipulation of JS from Ruby", () => {
         b
       `,
       result: 1
+    },
+    {
+      expr: `
+        function_to_call = JS.eval('return { a: (callback) => { callback(1) } }')
+        b = nil
+        function_to_call.call(:a) { |a| b = a }
+        b
+      `,
+      result: 1
     }
   ])(`JS::Object#call (%s)`, async (props) => {
     const vm = await initRubyVM();

--- a/packages/npm-packages/ruby-wasm-wasi/test/js_from_rb.test.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/test/js_from_rb.test.ts
@@ -139,6 +139,16 @@ describe("Manipulation of JS from Ruby", () => {
         b
       `,
       result: 1
+    },
+    {
+      expr: `
+        function_to_call = JS.eval('let callback; return { a: (c) => { callback = c }, b: () => { callback(1) } }')
+        b = nil
+        function_to_call.call(:a) { |a| b = a }
+        function_to_call.call(:b)
+        b
+      `,
+      result: 1
     }
   ])(`JS::Object#call (%s)`, async (props) => {
     const vm = await initRubyVM();


### PR DESCRIPTION
This PR emerged from the discussion in #32.

## Use Case

In JavaScript many functions accept a callback function as an argument. One example is the function `document.addEventListener` which is excessively used for web applications. The goal of this PR is to allow calling such functions and pass a Ruby Proc as callback function.

## Solution

The solution to this problem is to implement the Proc#to_js function. This will wrap the Proc's RbValue into a JavaScript function that calls the `call` method on the Proc when executed. This makes it possible to write code like this:

```js
JS.global[:document].call(:addEventListener, 'DOMContentLoaded', Proc.new do |e|
  puts e
end)
```

For convenience `JS::Object#call` was extended to detect passed blocks and turn them into a Proc argument. This allows the above code to be simplified like this:

```js
JS.global[:document].call(:addEventListener, 'DOMContentLoaded') do |e|
  puts e
end
```

All arguments passed to the callback function are wrapped into a Ruby JS::Object object and passed to the Proc.

## Problem

There seems to be a problem related to garbage collection when passing a Ruby object pointer to JavaScript and use it there. It seems like the garbage collector can collect such objects because there is no reference to them anymore. To prevent this I implemented a quite dirty hack in `RubyVM#rbValueofPointer` that registers the object on the wit api extension which then keeps a reference to this object which in turn prevents garbage collection. There is probably a better way of handling this. Maybe we can keep track of Ruby objects passed to JS in the JS extension as well? I'm not sure maybe somebody has a suggestion?

<details>
<summary>Note: This is also reproducible with ruby.wasm/main using JS::Object::wrap</summary>

```js
import { DefaultRubyVM } from 'ruby-head-wasm-wasi/dist/browser.umd';
const main = async () => {
  const response = await fetch(
    "https://cdn.jsdelivr.net/npm/ruby-head-wasm-wasi@next/dist/ruby.debug+stdlib.wasm"
  );
  const buffer = await response.arrayBuffer();
  const module = await WebAssembly.compile(buffer);
  const { vm } = await DefaultRubyVM(module);

  window.foo = (callback) => {
    setTimeout(() => {
      callback.call('call')
    }, 5000)
  }

  vm.eval(`
    require "js"
    def foo
      a = -> { puts "foo" }
      JS.global.call(:foo, JS::Object.wrap(a))
      nil
    end

    foo
    GC.start
  `);
};

main()
```

```
Uncaught RuntimeError: memory access out of bounds
    at rb_id_table_lookup (09ee12a2:0x536d0d)
    at callable_method_entry (09ee12a2:0x5ae6cd)
    at gccct_method_search_slowpath (09ee12a2:0x5c6c94)
    at rb_funcallv (09ee12a2:0x5bea0d)
    at rb_funcallv_thunk (09ee12a2:0x9698)
    at rb_protect (09ee12a2:0x25c0f5)
    at rb_abi_guest_rb_funcallv_protect (09ee12a2:0x97b0)
    at __wasm_export_rb_abi_guest_rb_funcallv_protect (09ee12a2:0xa4d3)
    at RbAbiGuest.rbFuncallvProtect (browser.umd.js:669:33)
    at callRbMethod (browser.umd.js:1456:40)
```
</details>