### PR TITLE
Update installation instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Dependencies: [wasi-vfs](https://github.com/kateinoigakukun/wasi-vfs), [wasmtime
 
 ```console
 # Download a prebuilt Ruby release
-$ curl -LO https://github.com/ruby/ruby.wasm/releases/download/2022-03-28-a/ruby-head-wasm32-unknown-wasi-full.tar.gz
+$ curl -LO https://github.com/ruby/ruby.wasm/releases/latest/download/ruby-head-wasm32-unknown-wasi-full.tar.gz
 $ tar xfz ruby-head-wasm32-unknown-wasi-full.tar.gz
 
 # Extract ruby binary not to pack itself

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Dependencies: [wasi-vfs](https://github.com/kateinoigakukun/wasi-vfs), [wasmtime
 
 ```console
 # Download a prebuilt Ruby release
-$ curl -LO https://github.com/kateinoigakukun/ruby.wasm/releases/download/2022-03-28-a/ruby-head-wasm32-unknown-wasi-full.tar.gz
+$ curl -LO https://github.com/ruby/ruby.wasm/releases/download/2022-03-28-a/ruby-head-wasm32-unknown-wasi-full.tar.gz
 $ tar xfz ruby-head-wasm32-unknown-wasi-full.tar.gz
 
 # Extract ruby binary not to pack itself


### PR DESCRIPTION
Hi @kateinoigakukun, thank you for providing [a great talk](https://speakerdeck.com/kateinoigakukun/ruby-meets-webassembly) at RubyKaigi 2022!

I had a try and found a glitch in the installation instruction.

- The old download URL `https://github.com/kateinoigakukun/ruby.wasm/releases/download/2022-03-28-a/ruby-head-wasm32-unknown-wasi-full.tar.gz` returns 404. 238d85fcc784e8623b675d3cb440d82bea03d4c3 addresses it.
- It might be controversial though, hard-coding the release version is not a good idea, especially for very active projects like ruby.wasm. GitHub provides a download URL for the latest release, so why not use it? de76a0943163b17783d2ce913deb1af0bcc3a199 addresses it.