### PR TITLE
Allow out-of-source build

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -43,13 +43,16 @@ BUILDS = [
   { src: "head", target: "wasm32-unknown-emscripten", profile: "full" },
 ]
 
+LIB_ROOT = File.dirname(__FILE__)
+
 namespace :build do
   BUILDS.each do |params|
     name = "#{params[:src]}-#{params[:target]}-#{params[:profile]}"
     source = BUILD_SOURCES[params[:src]].merge(name: params[:src])
     toolchain = RubyWasm::Toolchain.get params[:target]
     user_exts = BUILD_PROFILES[params[:profile]][:user_exts].map do |ext|
-      RubyWasm::CrossRubyExtProduct.new(ext, toolchain)
+      srcdir = File.join(LIB_ROOT, "ext", ext)
+      RubyWasm::CrossRubyExtProduct.new(srcdir, toolchain)
     end
     options = params
         .merge(BUILD_PROFILES[params[:profile]])

--- a/lib/ruby_wasm/build_system/product/baseruby.rb
+++ b/lib/ruby_wasm/build_system/product/baseruby.rb
@@ -11,10 +11,12 @@ module RubyWasm
       @channel = source.name
     end
 
+    def product_build_dir
+      File.join(@build_dir, RbConfig::CONFIG["host"], "baseruby-#{@channel}")
+    end
+
     def install_dir
-      File.join(
-        @build_dir, RbConfig::CONFIG["host"], "opt", "baseruby-#{@channel}"
-      )
+      File.join(product_build_dir, "opt")
     end
 
     def name
@@ -22,22 +24,20 @@ module RubyWasm
     end
 
     def define_task
-      baseruby_build_dir =
-        File.join(@build_dir, RbConfig::CONFIG["host"], "baseruby-#{@channel}")
 
-      directory baseruby_build_dir
+      directory product_build_dir
 
       desc "build baseruby #{@channel}"
       @install_task =
         task name => [
                source.src_dir,
                source.configure_file,
-               baseruby_build_dir
+               product_build_dir
              ] do
           next if Dir.exist?(install_dir)
           sh "#{source.configure_file} --prefix=#{install_dir} --disable-install-doc",
-             chdir: baseruby_build_dir
-          sh "make install", chdir: baseruby_build_dir
+             chdir: product_build_dir
+          sh "make install", chdir: product_build_dir
         end
     end
   end

--- a/lib/ruby_wasm/build_system/product/baseruby.rb
+++ b/lib/ruby_wasm/build_system/product/baseruby.rb
@@ -3,7 +3,7 @@ require_relative "./product"
 
 module RubyWasm
   class BaseRubyProduct < BuildProduct
-    attr_reader :base_dir, :source, :install_task
+    attr_reader :source, :install_task
 
     def initialize(build_dir, source)
       @build_dir = build_dir

--- a/lib/ruby_wasm/build_system/product/baseruby.rb
+++ b/lib/ruby_wasm/build_system/product/baseruby.rb
@@ -5,16 +5,15 @@ module RubyWasm
   class BaseRubyProduct < BuildProduct
     attr_reader :base_dir, :source, :install_task
 
-    def initialize(channel, base_dir, source)
-      @channel = channel
+    def initialize(base_dir, source)
       @base_dir = base_dir
       @source = source
+      @channel = source.name
     end
 
     def install_dir
       File.join(
-        base_dir,
-        "/build/deps/#{RbConfig::CONFIG["host"]}/opt/baseruby-#{@channel}"
+        base_dir, "build", RbConfig::CONFIG["host"], "opt", "baseruby-#{@channel}"
       )
     end
 
@@ -24,10 +23,7 @@ module RubyWasm
 
     def define_task
       baseruby_build_dir =
-        File.join(
-          base_dir,
-          "/build/deps/#{RbConfig::CONFIG["host"]}/baseruby-#{@channel}"
-        )
+        File.join(base_dir, "build", RbConfig::CONFIG["host"], "baseruby-#{@channel}")
 
       directory baseruby_build_dir
 

--- a/lib/ruby_wasm/build_system/product/baseruby.rb
+++ b/lib/ruby_wasm/build_system/product/baseruby.rb
@@ -5,15 +5,15 @@ module RubyWasm
   class BaseRubyProduct < BuildProduct
     attr_reader :base_dir, :source, :install_task
 
-    def initialize(base_dir, source)
-      @base_dir = base_dir
+    def initialize(build_dir, source)
+      @build_dir = build_dir
       @source = source
       @channel = source.name
     end
 
     def install_dir
       File.join(
-        base_dir, "build", RbConfig::CONFIG["host"], "opt", "baseruby-#{@channel}"
+        @build_dir, RbConfig::CONFIG["host"], "opt", "baseruby-#{@channel}"
       )
     end
 
@@ -23,7 +23,7 @@ module RubyWasm
 
     def define_task
       baseruby_build_dir =
-        File.join(base_dir, "build", RbConfig::CONFIG["host"], "baseruby-#{@channel}")
+        File.join(@build_dir, RbConfig::CONFIG["host"], "baseruby-#{@channel}")
 
       directory baseruby_build_dir
 

--- a/lib/ruby_wasm/build_system/product/crossruby.rb
+++ b/lib/ruby_wasm/build_system/product/crossruby.rb
@@ -56,11 +56,12 @@ module RubyWasm
   end
 
   class CrossRubyProduct < BuildProduct
-    attr_reader :base_dir, :source, :toolchain, :build, :configure
+    attr_reader :source, :toolchain, :build, :configure
 
-    def initialize(params, base_dir, baseruby, source, toolchain)
+    def initialize(params, build_dir, rubies_dir, baseruby, source, toolchain)
       @params = params
-      @base_dir = base_dir
+      @rubies_dir = rubies_dir
+      @build_dir = build_dir
       @baseruby = baseruby
       @source = source
       @toolchain = toolchain
@@ -127,11 +128,11 @@ module RubyWasm
     end
 
     def build_dir
-      "#{@base_dir}/build/build/#{name}"
+      File.join(@build_dir, @params.target, name)
     end
 
     def ext_build_dir
-      "#{@base_dir}/build/ext-build/#{name}"
+      File.join(@build_dir, @params.target, name + "-ext")
     end
 
     def with_libyaml(libyaml)
@@ -145,7 +146,7 @@ module RubyWasm
     end
 
     def dest_dir
-      "#{@base_dir}/rubies/#{name}"
+      File.join(@rubies_dir, name)
     end
 
     def extinit_obj

--- a/lib/ruby_wasm/build_system/product/libyaml.rb
+++ b/lib/ruby_wasm/build_system/product/libyaml.rb
@@ -28,7 +28,7 @@ module RubyWasm
           next if Dir.exist?(install_root)
 
           build_dir =
-            File.join(base_dir, "/build/deps/#{target}/yaml-#{libyaml_version}")
+            File.join(base_dir, "build", target, "yaml-#{libyaml_version}")
           mkdir_p File.dirname(build_dir)
           rm_rf build_dir
           sh "curl -L https://github.com/yaml/libyaml/releases/download/#{libyaml_version}/yaml-#{libyaml_version}.tar.gz | tar xz",

--- a/lib/ruby_wasm/build_system/product/libyaml.rb
+++ b/lib/ruby_wasm/build_system/product/libyaml.rb
@@ -5,8 +5,8 @@ module RubyWasm
   class LibYAMLProduct < AutoconfProduct
     attr_reader :base_dir, :install_dir, :target, :install_task
 
-    def initialize(base_dir, install_dir, target, toolchain)
-      @base_dir = base_dir
+    def initialize(build_dir, install_dir, target, toolchain)
+      @build_dir = build_dir
       @install_dir = install_dir
       @target = target
       super(target, toolchain)
@@ -27,19 +27,19 @@ module RubyWasm
         task(name) do
           next if Dir.exist?(install_root)
 
-          build_dir =
-            File.join(base_dir, "build", target, "yaml-#{libyaml_version}")
-          mkdir_p File.dirname(build_dir)
-          rm_rf build_dir
+          product_build_dir =
+            File.join(@build_dir, target, "yaml-#{libyaml_version}")
+          mkdir_p File.dirname(product_build_dir)
+          rm_rf product_build_dir
           sh "curl -L https://github.com/yaml/libyaml/releases/download/#{libyaml_version}/yaml-#{libyaml_version}.tar.gz | tar xz",
-             chdir: File.dirname(build_dir)
+             chdir: File.dirname(product_build_dir)
 
           # obtain the latest config.guess and config.sub for Emscripten and WASI triple support
-          sh "curl -o #{build_dir}/config/config.guess 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'"
-          sh "curl -o #{build_dir}/config/config.sub 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'"
+          sh "curl -o #{product_build_dir}/config/config.guess 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'"
+          sh "curl -o #{product_build_dir}/config/config.sub 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'"
 
-          sh "./configure #{configure_args.join(" ")}", chdir: build_dir
-          sh "make install DESTDIR=#{install_dir}", chdir: build_dir
+          sh "./configure #{configure_args.join(" ")}", chdir: product_build_dir
+          sh "make install DESTDIR=#{install_dir}", chdir: product_build_dir
         end
     end
   end

--- a/lib/ruby_wasm/build_system/product/libyaml.rb
+++ b/lib/ruby_wasm/build_system/product/libyaml.rb
@@ -3,17 +3,26 @@ require_relative "./product"
 
 module RubyWasm
   class LibYAMLProduct < AutoconfProduct
-    attr_reader :base_dir, :install_dir, :target, :install_task
+    attr_reader :target, :install_task
 
-    def initialize(build_dir, install_dir, target, toolchain)
+    LIBYAML_VERSION = "0.2.5"
+
+    def initialize(build_dir, target, toolchain)
       @build_dir = build_dir
-      @install_dir = install_dir
       @target = target
       super(target, toolchain)
     end
 
+    def product_build_dir
+      File.join(@build_dir, target, "yaml-#{LIBYAML_VERSION}")
+    end
+
+    def destdir
+      File.join(product_build_dir, "opt")
+    end
+
     def install_root
-      File.join(install_dir, "usr/local")
+      File.join(destdir, "usr", "local")
     end
 
     def name
@@ -21,17 +30,14 @@ module RubyWasm
     end
 
     def define_task
-      libyaml_version = "0.2.5"
-      desc "build libyaml #{libyaml_version} for #{target}"
+      desc "build libyaml #{LIBYAML_VERSION} for #{target}"
       @install_task =
         task(name) do
           next if Dir.exist?(install_root)
 
-          product_build_dir =
-            File.join(@build_dir, target, "yaml-#{libyaml_version}")
           mkdir_p File.dirname(product_build_dir)
           rm_rf product_build_dir
-          sh "curl -L https://github.com/yaml/libyaml/releases/download/#{libyaml_version}/yaml-#{libyaml_version}.tar.gz | tar xz",
+          sh "curl -L https://github.com/yaml/libyaml/releases/download/#{LIBYAML_VERSION}/yaml-#{LIBYAML_VERSION}.tar.gz | tar xz",
              chdir: File.dirname(product_build_dir)
 
           # obtain the latest config.guess and config.sub for Emscripten and WASI triple support
@@ -39,7 +45,7 @@ module RubyWasm
           sh "curl -o #{product_build_dir}/config/config.sub 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'"
 
           sh "./configure #{configure_args.join(" ")}", chdir: product_build_dir
-          sh "make install DESTDIR=#{install_dir}", chdir: product_build_dir
+          sh "make install DESTDIR=#{destdir}", chdir: product_build_dir
         end
     end
   end

--- a/lib/ruby_wasm/build_system/product/ruby_source.rb
+++ b/lib/ruby_wasm/build_system/product/ruby_source.rb
@@ -13,11 +13,11 @@ module RubyWasm
     end
 
     def src_dir
-      "#{@base_dir}/build/src/#{@params[:name]}"
+      File.join(@base_dir, "build", "checkouts", @params[:name])
     end
 
     def configure_file
-      "#{src_dir}/configure"
+      File.join(src_dir, "configure")
     end
 
     def fetch

--- a/lib/ruby_wasm/build_system/product/ruby_source.rb
+++ b/lib/ruby_wasm/build_system/product/ruby_source.rb
@@ -3,9 +3,9 @@ require_relative "./product"
 
 module RubyWasm
   class BuildSource < BuildProduct
-    def initialize(params, base_dir)
+    def initialize(params, build_dir)
       @params = params
-      @base_dir = base_dir
+      @build_dir = build_dir
     end
 
     def name
@@ -13,7 +13,7 @@ module RubyWasm
     end
 
     def src_dir
-      File.join(@base_dir, "build", "checkouts", @params[:name])
+      File.join(@build_dir, "checkouts", @params[:name])
     end
 
     def configure_file

--- a/lib/ruby_wasm/build_system/product/zlib.rb
+++ b/lib/ruby_wasm/build_system/product/zlib.rb
@@ -28,7 +28,7 @@ module RubyWasm
           next if Dir.exist?(install_root)
 
           build_dir =
-            File.join(base_dir, "/build/deps/#{target}/zlib-#{zlib_version}")
+            File.join(base_dir, "build", target, "zlib-#{zlib_version}")
           mkdir_p File.dirname(build_dir)
           rm_rf build_dir
 

--- a/lib/ruby_wasm/build_system/product/zlib.rb
+++ b/lib/ruby_wasm/build_system/product/zlib.rb
@@ -3,13 +3,12 @@ require_relative "./product"
 
 module RubyWasm
   class ZlibProduct < AutoconfProduct
-    attr_reader :install_dir, :target, :install_task
+    attr_reader :target, :install_task
 
     ZLIB_VERSION = "1.2.12"
 
-    def initialize(build_dir, install_dir, target, toolchain)
+    def initialize(build_dir, target, toolchain)
       @build_dir = build_dir
-      @install_dir = install_dir
       @target = target
       super(target, toolchain)
     end

--- a/lib/ruby_wasm/build_system/product/zlib.rb
+++ b/lib/ruby_wasm/build_system/product/zlib.rb
@@ -3,10 +3,10 @@ require_relative "./product"
 
 module RubyWasm
   class ZlibProduct < AutoconfProduct
-    attr_reader :base_dir, :install_dir, :target, :install_task
+    attr_reader :install_dir, :target, :install_task
 
-    def initialize(base_dir, install_dir, target, toolchain)
-      @base_dir = base_dir
+    def initialize(build_dir, install_dir, target, toolchain)
+      @build_dir = build_dir
       @install_dir = install_dir
       @target = target
       super(target, toolchain)
@@ -27,17 +27,17 @@ module RubyWasm
         task(name) do
           next if Dir.exist?(install_root)
 
-          build_dir =
-            File.join(base_dir, "build", target, "zlib-#{zlib_version}")
-          mkdir_p File.dirname(build_dir)
-          rm_rf build_dir
+          product_build_dir =
+            File.join(@build_dir, target, "zlib-#{zlib_version}")
+          mkdir_p File.dirname(product_build_dir)
+          rm_rf product_build_dir
 
           sh "curl -L https://zlib.net/zlib-#{zlib_version}.tar.gz | tar xz",
-             chdir: File.dirname(build_dir)
+             chdir: File.dirname(product_build_dir)
 
           sh "#{tools_args.join(" ")} ./configure --prefix=#{install_root} --static",
-             chdir: build_dir
-          sh "make install", chdir: build_dir
+             chdir: product_build_dir
+          sh "make install", chdir: product_build_dir
         end
     end
   end

--- a/lib/ruby_wasm/build_system/product/zlib.rb
+++ b/lib/ruby_wasm/build_system/product/zlib.rb
@@ -5,6 +5,8 @@ module RubyWasm
   class ZlibProduct < AutoconfProduct
     attr_reader :install_dir, :target, :install_task
 
+    ZLIB_VERSION = "1.2.12"
+
     def initialize(build_dir, install_dir, target, toolchain)
       @build_dir = build_dir
       @install_dir = install_dir
@@ -12,8 +14,16 @@ module RubyWasm
       super(target, toolchain)
     end
 
+    def product_build_dir
+      File.join(@build_dir, target, "zlib-#{ZLIB_VERSION}")
+    end
+
+    def destdir
+      File.join(product_build_dir, "opt")
+    end
+
     def install_root
-      File.join(install_dir, "zlib")
+      File.join(destdir, "usr", "local")
     end
 
     def name
@@ -21,23 +31,20 @@ module RubyWasm
     end
 
     def define_task
-      zlib_version = "1.2.12"
-      desc "build zlib #{zlib_version} for #{target}"
+      desc "build zlib #{ZLIB_VERSION} for #{target}"
       @install_task =
         task(name) do
           next if Dir.exist?(install_root)
 
-          product_build_dir =
-            File.join(@build_dir, target, "zlib-#{zlib_version}")
           mkdir_p File.dirname(product_build_dir)
           rm_rf product_build_dir
 
-          sh "curl -L https://zlib.net/zlib-#{zlib_version}.tar.gz | tar xz",
+          sh "curl -L https://zlib.net/zlib-#{ZLIB_VERSION}.tar.gz | tar xz",
              chdir: File.dirname(product_build_dir)
 
-          sh "#{tools_args.join(" ")} ./configure --prefix=#{install_root} --static",
+          sh "#{tools_args.join(" ")} ./configure --static",
              chdir: product_build_dir
-          sh "make install", chdir: product_build_dir
+          sh "make install DESTDIR=#{destdir}", chdir: product_build_dir
         end
     end
   end

--- a/lib/ruby_wasm/rake_task.rb
+++ b/lib/ruby_wasm/rake_task.rb
@@ -12,7 +12,7 @@ class RubyWasm::BuildTask < ::Rake::TaskLib
     zlib = add_product RubyWasm::ZlibProduct.new(base_dir, install_dir, target, toolchain)
 
     source = add_product RubyWasm::BuildSource.new(src, base_dir)
-    baseruby = add_product RubyWasm::BaseRubyProduct.new(name, base_dir, source)
+    baseruby = add_product RubyWasm::BaseRubyProduct.new(base_dir, source)
 
     build_params = RubyWasm::BuildParams.new(
       options.merge(

--- a/lib/ruby_wasm/rake_task.rb
+++ b/lib/ruby_wasm/rake_task.rb
@@ -3,10 +3,9 @@ require_relative "./build_system"
 
 class RubyWasm::BuildTask < ::Rake::TaskLib
 
-  def initialize(name, target:, src:, extensions: [], toolchain: nil, **options, &task_block)
-    base_dir = Dir.pwd
-    build_dir = File.join(base_dir, "build")
-    rubies_dir = File.join(base_dir, "rubies")
+  def initialize(name, target:, src:, extensions: [], toolchain: nil, build_dir: nil, rubies_dir: nil, **options, &task_block)
+    build_dir ||= File.join(Dir.pwd, "build")
+    rubies_dir ||= File.join(Dir.pwd, "rubies")
     toolchain ||= RubyWasm::Toolchain.get target
 
     libyaml = add_product RubyWasm::LibYAMLProduct.new(build_dir, target, toolchain)

--- a/lib/ruby_wasm/rake_task.rb
+++ b/lib/ruby_wasm/rake_task.rb
@@ -6,10 +6,11 @@ class RubyWasm::BuildTask < ::Rake::TaskLib
   def initialize(name, target:, src:, extensions: [], toolchain: nil, **options, &task_block)
     base_dir = Dir.pwd
     build_dir = File.join(base_dir, "build")
+    rubies_dir = File.join(base_dir, "rubies")
     install_dir = File.join(base_dir, "/build/deps/#{target}/opt")
     toolchain ||= RubyWasm::Toolchain.get target
 
-    libyaml = add_product RubyWasm::LibYAMLProduct.new(build_dir, install_dir, target, toolchain)
+    libyaml = add_product RubyWasm::LibYAMLProduct.new(build_dir, target, toolchain)
     zlib = add_product RubyWasm::ZlibProduct.new(build_dir, install_dir, target, toolchain)
 
     source = add_product RubyWasm::BuildSource.new(src, build_dir)
@@ -21,7 +22,7 @@ class RubyWasm::BuildTask < ::Rake::TaskLib
       )
     )
 
-    product = RubyWasm::CrossRubyProduct.new(build_params, base_dir, baseruby, source, toolchain)
+    product = RubyWasm::CrossRubyProduct.new(build_params, build_dir, rubies_dir, baseruby, source, toolchain)
     product.with_libyaml libyaml
     product.with_zlib zlib
     product.define_task

--- a/lib/ruby_wasm/rake_task.rb
+++ b/lib/ruby_wasm/rake_task.rb
@@ -21,9 +21,6 @@ class RubyWasm::BuildTask < ::Rake::TaskLib
       )
     )
 
-    exts = extensions.map do |ext|
-      RubyWasm::CrossRubyExtProduct.new(ext, toolchain)
-    end
     product = RubyWasm::CrossRubyProduct.new(build_params, base_dir, baseruby, source, toolchain)
     product.with_libyaml libyaml
     product.with_zlib zlib

--- a/lib/ruby_wasm/rake_task.rb
+++ b/lib/ruby_wasm/rake_task.rb
@@ -5,14 +5,15 @@ class RubyWasm::BuildTask < ::Rake::TaskLib
 
   def initialize(name, target:, src:, extensions: [], toolchain: nil, **options, &task_block)
     base_dir = Dir.pwd
+    build_dir = File.join(base_dir, "build")
     install_dir = File.join(base_dir, "/build/deps/#{target}/opt")
     toolchain ||= RubyWasm::Toolchain.get target
 
-    libyaml = add_product RubyWasm::LibYAMLProduct.new(base_dir, install_dir, target, toolchain)
-    zlib = add_product RubyWasm::ZlibProduct.new(base_dir, install_dir, target, toolchain)
+    libyaml = add_product RubyWasm::LibYAMLProduct.new(build_dir, install_dir, target, toolchain)
+    zlib = add_product RubyWasm::ZlibProduct.new(build_dir, install_dir, target, toolchain)
 
-    source = add_product RubyWasm::BuildSource.new(src, base_dir)
-    baseruby = add_product RubyWasm::BaseRubyProduct.new(base_dir, source)
+    source = add_product RubyWasm::BuildSource.new(src, build_dir)
+    baseruby = add_product RubyWasm::BaseRubyProduct.new(build_dir, source)
 
     build_params = RubyWasm::BuildParams.new(
       options.merge(

--- a/lib/ruby_wasm/rake_task.rb
+++ b/lib/ruby_wasm/rake_task.rb
@@ -7,11 +7,10 @@ class RubyWasm::BuildTask < ::Rake::TaskLib
     base_dir = Dir.pwd
     build_dir = File.join(base_dir, "build")
     rubies_dir = File.join(base_dir, "rubies")
-    install_dir = File.join(base_dir, "/build/deps/#{target}/opt")
     toolchain ||= RubyWasm::Toolchain.get target
 
     libyaml = add_product RubyWasm::LibYAMLProduct.new(build_dir, target, toolchain)
-    zlib = add_product RubyWasm::ZlibProduct.new(build_dir, install_dir, target, toolchain)
+    zlib = add_product RubyWasm::ZlibProduct.new(build_dir, target, toolchain)
 
     source = add_product RubyWasm::BuildSource.new(src, build_dir)
     baseruby = add_product RubyWasm::BaseRubyProduct.new(build_dir, source)


### PR DESCRIPTION
This PR makes the build system current-working-directory independent, and re-organize build directory structure.

```
$ tree -L 2 build
build
├── checkouts
│   └── head
├── wasm32-unknown-wasi
│   ├── head-wasm32-unknown-wasi-full-js
│   ├── head-wasm32-unknown-wasi-full-js-ext
│   ├── yaml-0.2.5
│   └── zlib-1.2.12
└── x86_64-pc-linux-gnu
    └── baseruby-head
```

