### PR TITLE
Enable src attribute in script tag in browser.script.iife.js.

### DIFF
--- a/packages/npm-packages/ruby-wasm-wasi/src/browser.script.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/browser.script.ts
@@ -15,12 +15,18 @@ export const main = async (pkg: { name: string, version: string }) => {
     runRubyScriptsInHtml(vm);
 };
 
-const runRubyScriptsInHtml = (vm) => {
+const runRubyScriptsInHtml = async (vm) => {
     const tags = document.getElementsByTagName("script");
     for (var i = 0, len = tags.length; i < len; i++) {
         const tag = tags[i];
         if (tag.type === "text/ruby") {
-            if (tag.innerHTML) {
+            if (tag.hasAttribute('src')){
+                const response = await fetch(
+                    tag.getAttribute('src')
+                );
+                const rubyScript = await response.text();
+                vm.eval(rubyScript);
+            } else if (tag.innerHTML) {
                 vm.eval(tag.innerHTML);
             }
         }


### PR DESCRIPTION
Ruby scripts written inline in script tags do not receive syntax highlighting support in editors such as VSCode.

This patch will allow us to call external files using the src attribute.
Once this is enabled, Ruby scripts can be written in files with the extension rb. Then we can get syntax highlighting support without any special editor configuration.

I did not know how to build `browser.script.iife.js`, so I did not build it and test this patch.
I applied this patch to https://cdn.jsdelivr.net/npm/ruby-head-wasm-wasi@0.3.0-2022-09-06-f/dist/browser.script.iife.js to see if it works.