### PR TITLE
Repair debug build

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -51,10 +51,10 @@ namespace :build do
   BUILDS.each do |params|
     name = "#{params[:src]}-#{params[:target]}-#{params[:profile]}"
     source = BUILD_SOURCES[params[:src]].merge(name: params[:src])
-    debug = params[:debug]
     options = params
         .merge(BUILD_PROFILES[params[:profile]])
         .merge(src: source)
+    debug = options[:debug]
     options.delete :profile
     options.delete :user_exts
     options.delete :debug

--- a/packages/npm-packages/ruby-wasm-wasi/test/package.test.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/test/package.test.ts
@@ -43,4 +43,13 @@ describe("Packaging validation", () => {
       vm.eval(`require "English"`);
     }
   });
+
+  test("ruby.debug+stdlib.wasm has debug info", async () => {
+    const binary = await fs.readFile(
+      path.join(__dirname, `./../dist/ruby.debug+stdlib.wasm`)
+    );
+    const mod = await WebAssembly.compile(binary.buffer);
+    const nameSections = WebAssembly.Module.customSections(mod, "name");
+    expect(nameSections.length).toBe(1);
+  })
 });


### PR DESCRIPTION
It's broken since https://github.com/ruby/ruby.wasm/commit/15fff06f8806bc6e6c05826d95a55abe28e8134a and `name` section had been lost between [2022-10-09-a](https://github.com/ruby/ruby.wasm/releases/tag/2022-10-09-a)...[2022-09-20-a](https://github.com/ruby/ruby.wasm/releases/tag/2022-09-20-a)