### PR TITLE
Stop using specific ABI version values in testing

### DIFF
--- a/packages/npm-packages/ruby-wasm-wasi/test/js_from_rb.test.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/test/js_from_rb.test.ts
@@ -4,11 +4,10 @@ import { initRubyVM } from "./init";
 describe("Manipulation of JS from Ruby", () => {
   jest.setTimeout(10 /*sec*/ * 1000);
 
-  const Qtrue = 0x02;
   test(`require "js"`, async () => {
     const vm = await initRubyVM();
     const result = vm.eval(`require "js"`);
-    expect((result as any).inner._wasm_val).toBe(Qtrue);
+    expect(result.toString()).toBe("true");
   });
 
   test("JS::Object#method_missing with block", async () => {

--- a/packages/npm-packages/ruby-wasm-wasi/test/vm.test.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/test/vm.test.ts
@@ -5,7 +5,7 @@ describe("RubyVM", () => {
   test("empty expression", async () => {
     const vm = await initRubyVM();
     const result = vm.eval("");
-    expect((result as any).inner._wasm_val).toBe(/* Qnil */ 4);
+    expect(result.toString()).toBe("");
   });
   test("nil toString", async () => {
     const vm = await initRubyVM();


### PR DESCRIPTION
The special const values are updated in https://github.com/ruby/ruby/commit/f55212bce939f736559709a8cd16c409772389c8