### PR TITLE
Fix use-after-free in JS::Object#[]= for to_js'ed assigned value

### DIFF
--- a/ext/js/js-core.c
+++ b/ext/js/js-core.c
@@ -182,11 +182,13 @@ static VALUE _rb_js_obj_aref(VALUE obj, VALUE key) {
  */
 static VALUE _rb_js_obj_aset(VALUE obj, VALUE key, VALUE val) {
   struct jsvalue *p = check_jsvalue(obj);
-  struct jsvalue *v = check_jsvalue(_rb_js_try_convert(rb_mJS, val));
+  VALUE rv = _rb_js_try_convert(rb_mJS, val);
+  struct jsvalue *v = check_jsvalue(rv);
   rb_js_abi_host_string_t key_abi_str;
   key = rb_obj_as_string(key);
   rstring_to_abi_string(key, &key_abi_str);
   rb_js_abi_host_reflect_set(p->abi, &key_abi_str, v->abi);
+  RB_GC_GUARD(rv);
   return val;
 }
 

--- a/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
+++ b/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
@@ -146,6 +146,16 @@ class JS::TestObject < Test::Unit::TestCase
     assert_equal "1,2,3", JS.global.call(:Array, 1, 2, 3).to_s
   end
 
+  def test_call_with_stress_gc
+    obj = JS.eval(<<~JS)
+      return { takeArg() {} }
+    JS
+    GC.stress = true
+    obj.call(:takeArg, "1")
+    obj.call(:takeArg) {}
+    GC.stress = false
+  end
+
   def test_method_missing
     assert_equal "42", JS.eval("return 42;").toString.to_s
     assert_equal "o", JS.eval("return 'hello';").charAt(4).to_s

--- a/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
+++ b/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
@@ -203,4 +203,10 @@ class JS::TestObject < Test::Unit::TestCase
     object["foo"] = 42
     assert_equal 42.to_s, object["foo"].to_s
   end
+
+  def test_member_set_with_stress_gc
+    GC.stress = true
+    JS.global[:tmp] = "1"
+    GC.stress = false
+  end
 end


### PR DESCRIPTION
Reported by @mame 