### PR TITLE
Remove rake dependency from build library

### DIFF
--- a/lib/ruby_wasm/build_system.rb
+++ b/lib/ruby_wasm/build_system.rb
@@ -1,4 +1,3 @@
-require "rake"
 require_relative "build_system/build_params"
 require_relative "build_system/product"
 require_relative "build_system/toolchain"

--- a/lib/ruby_wasm/build_system/product.rb
+++ b/lib/ruby_wasm/build_system/product.rb
@@ -1,4 +1,3 @@
-require "rake"
 require_relative "product/product"
 require_relative "product/ruby_source"
 require_relative "product/baseruby"

--- a/lib/ruby_wasm/build_system/product/baseruby.rb
+++ b/lib/ruby_wasm/build_system/product/baseruby.rb
@@ -1,4 +1,3 @@
-require "rake"
 require_relative "./product"
 
 module RubyWasm
@@ -25,7 +24,7 @@ module RubyWasm
 
     def build
       FileUtils.mkdir_p product_build_dir
-      Rake::Task[source.configure_file].invoke
+      @source.build
       return if Dir.exist?(install_dir)
       Dir.chdir(product_build_dir) do
         system "#{source.configure_file} --prefix=#{install_dir} --disable-install-doc"

--- a/lib/ruby_wasm/build_system/product/baseruby.rb
+++ b/lib/ruby_wasm/build_system/product/baseruby.rb
@@ -23,20 +23,14 @@ module RubyWasm
       "baseruby-#{@channel}"
     end
 
-    def define_task
-      directory product_build_dir
-
-      @install_task =
-        task name => [
-               source.src_dir,
-               source.configure_file,
-               product_build_dir
-             ] do
-          next if Dir.exist?(install_dir)
-          sh "#{source.configure_file} --prefix=#{install_dir} --disable-install-doc",
-             chdir: product_build_dir
-          sh "make install", chdir: product_build_dir
-        end
+    def build
+      FileUtils.mkdir_p product_build_dir
+      Rake::Task[source.configure_file].invoke
+      return if Dir.exist?(install_dir)
+      Dir.chdir(product_build_dir) do
+        system "#{source.configure_file} --prefix=#{install_dir} --disable-install-doc"
+        system "make install"
+      end
     end
   end
 end

--- a/lib/ruby_wasm/build_system/product/baseruby.rb
+++ b/lib/ruby_wasm/build_system/product/baseruby.rb
@@ -2,8 +2,6 @@ require_relative "./product"
 
 module RubyWasm
   class BaseRubyProduct < BuildProduct
-    attr_reader :source, :install_task
-
     def initialize(build_dir, source)
       @build_dir = build_dir
       @source = source
@@ -27,7 +25,7 @@ module RubyWasm
       @source.build
       return if Dir.exist?(install_dir)
       Dir.chdir(product_build_dir) do
-        system "#{source.configure_file} --prefix=#{install_dir} --disable-install-doc"
+        system "#{@source.configure_file} --prefix=#{install_dir} --disable-install-doc"
         system "make install"
       end
     end

--- a/lib/ruby_wasm/build_system/product/crossruby.rb
+++ b/lib/ruby_wasm/build_system/product/crossruby.rb
@@ -130,6 +130,7 @@ module RubyWasm
     def build(remake: false, reconfigure: false)
       FileUtils.mkdir_p dest_dir
       FileUtils.mkdir_p build_dir
+      @toolchain.install
       [@source, @baseruby, @libyaml, @zlib, @wasi_vfs].each(&:build)
       dep_tasks.each(&:invoke)
       configure(reconfigure: reconfigure)
@@ -196,7 +197,7 @@ module RubyWasm
     end
 
     def dep_tasks
-      [@toolchain.install_task] + @dep_tasks
+      @dep_tasks
     end
 
     def configure_args(build_triple, toolchain)

--- a/lib/ruby_wasm/build_system/product/crossruby.rb
+++ b/lib/ruby_wasm/build_system/product/crossruby.rb
@@ -123,7 +123,7 @@ module RubyWasm
 
     def build_exts
       @user_exts.each { |prod| prod.build(self) }
-      mkdir_p File.dirname(extinit_obj)
+      FileUtils.mkdir_p File.dirname(extinit_obj)
       system %Q(ruby #{extinit_c_erb} #{@user_exts.map(&:name).join(" ")} | #{toolchain.cc} -c -x c - -o #{extinit_obj})
     end
 

--- a/lib/ruby_wasm/build_system/product/crossruby.rb
+++ b/lib/ruby_wasm/build_system/product/crossruby.rb
@@ -64,8 +64,8 @@ module RubyWasm
       ]
       # Clear RUBYOPT to avoid loading unrelated bundle setup
       system ({ "RUBYOPT" => "" }),
-                   "#{crossruby.baseruby_path} #{extconf_args.join(" ")}",
-                   chdir: objdir
+             "#{crossruby.baseruby_path} #{extconf_args.join(" ")}",
+             chdir: objdir
     end
 
     def do_install_rb(crossruby)
@@ -115,8 +115,7 @@ module RubyWasm
     def configure(reconfigure: false)
       if !File.exist?("#{build_dir}/Makefile") || reconfigure
         args = configure_args(RbConfig::CONFIG["host"], toolchain)
-        system "#{source.configure_file} #{args.join(" ")}",
-                     chdir: build_dir
+        system "#{source.configure_file} #{args.join(" ")}", chdir: build_dir
       end
       # NOTE: we need rbconfig.rb at configuration time to build user given extensions with mkmf
       system "make rbconfig.rb", chdir: build_dir
@@ -131,8 +130,7 @@ module RubyWasm
     def build(remake: false, reconfigure: false)
       FileUtils.mkdir_p dest_dir
       FileUtils.mkdir_p build_dir
-      Rake::Task[source.configure_file].invoke
-      @baseruby.build
+      [@source, @baseruby].each(&:build)
       dep_tasks.each(&:invoke)
       configure(reconfigure: reconfigure)
       build_exts

--- a/lib/ruby_wasm/build_system/product/crossruby.rb
+++ b/lib/ruby_wasm/build_system/product/crossruby.rb
@@ -2,7 +2,7 @@ require_relative "./product"
 
 module RubyWasm
   class CrossRubyExtProduct < BuildProduct
-    attr_reader :name, :srcdir
+    attr_reader :name
     def initialize(srcdir, toolchain, name: nil)
       @srcdir, @toolchain = srcdir, toolchain
       @name = name || File.basename(srcdir)

--- a/lib/ruby_wasm/build_system/product/crossruby.rb
+++ b/lib/ruby_wasm/build_system/product/crossruby.rb
@@ -130,7 +130,7 @@ module RubyWasm
     def build(remake: false, reconfigure: false)
       FileUtils.mkdir_p dest_dir
       FileUtils.mkdir_p build_dir
-      [@source, @baseruby, @libyaml].each(&:build)
+      [@source, @baseruby, @libyaml, @zlib].each(&:build)
       dep_tasks.each(&:invoke)
       configure(reconfigure: reconfigure)
       build_exts
@@ -164,7 +164,6 @@ module RubyWasm
 
     def with_zlib(zlib)
       @zlib = zlib
-      @dep_tasks << zlib.install_task
     end
 
     def with_wasi_vfs(wasi_vfs)

--- a/lib/ruby_wasm/build_system/product/crossruby.rb
+++ b/lib/ruby_wasm/build_system/product/crossruby.rb
@@ -130,7 +130,7 @@ module RubyWasm
     def build(remake: false, reconfigure: false)
       FileUtils.mkdir_p dest_dir
       FileUtils.mkdir_p build_dir
-      [@source, @baseruby, @libyaml, @zlib].each(&:build)
+      [@source, @baseruby, @libyaml, @zlib, @wasi_vfs].each(&:build)
       dep_tasks.each(&:invoke)
       configure(reconfigure: reconfigure)
       build_exts
@@ -168,7 +168,6 @@ module RubyWasm
 
     def with_wasi_vfs(wasi_vfs)
       @wasi_vfs = wasi_vfs
-      wasi_vfs.install_task&.tap { |t| @dep_tasks << t }
     end
 
     def dest_dir

--- a/lib/ruby_wasm/build_system/product/crossruby.rb
+++ b/lib/ruby_wasm/build_system/product/crossruby.rb
@@ -130,7 +130,7 @@ module RubyWasm
     def build(remake: false, reconfigure: false)
       FileUtils.mkdir_p dest_dir
       FileUtils.mkdir_p build_dir
-      [@source, @baseruby].each(&:build)
+      [@source, @baseruby, @libyaml].each(&:build)
       dep_tasks.each(&:invoke)
       configure(reconfigure: reconfigure)
       build_exts
@@ -160,7 +160,6 @@ module RubyWasm
 
     def with_libyaml(libyaml)
       @libyaml = libyaml
-      @dep_tasks << libyaml.install_task
     end
 
     def with_zlib(zlib)

--- a/lib/ruby_wasm/build_system/product/libyaml.rb
+++ b/lib/ruby_wasm/build_system/product/libyaml.rb
@@ -1,9 +1,8 @@
-require "rake"
 require_relative "./product"
 
 module RubyWasm
   class LibYAMLProduct < AutoconfProduct
-    attr_reader :target, :install_task
+    attr_reader :target
 
     LIBYAML_VERSION = "0.2.5"
 
@@ -29,23 +28,20 @@ module RubyWasm
       product_build_dir
     end
 
-    def define_task
-      @install_task =
-        task name => [@toolchain.define_task] do
-          next if Dir.exist?(install_root)
+    def build
+      return if Dir.exist?(install_root)
 
-          mkdir_p File.dirname(product_build_dir)
-          rm_rf product_build_dir
-          sh "curl -L https://github.com/yaml/libyaml/releases/download/#{LIBYAML_VERSION}/yaml-#{LIBYAML_VERSION}.tar.gz | tar xz",
+      FileUtils.mkdir_p File.dirname(product_build_dir)
+      FileUtils.rm_rf product_build_dir
+      system "curl -L https://github.com/yaml/libyaml/releases/download/#{LIBYAML_VERSION}/yaml-#{LIBYAML_VERSION}.tar.gz | tar xz",
              chdir: File.dirname(product_build_dir)
 
-          # obtain the latest config.guess and config.sub for Emscripten and WASI triple support
-          sh "curl -o #{product_build_dir}/config/config.guess 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'"
-          sh "curl -o #{product_build_dir}/config/config.sub 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'"
+      # obtain the latest config.guess and config.sub for Emscripten and WASI triple support
+      system "curl -o #{product_build_dir}/config/config.guess 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'"
+      system "curl -o #{product_build_dir}/config/config.sub 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'"
 
-          sh "./configure #{configure_args.join(" ")}", chdir: product_build_dir
-          sh "make install DESTDIR=#{destdir}", chdir: product_build_dir
-        end
+      system "./configure #{configure_args.join(" ")}", chdir: product_build_dir
+      system "make install DESTDIR=#{destdir}", chdir: product_build_dir
     end
   end
 end

--- a/lib/ruby_wasm/build_system/product/product.rb
+++ b/lib/ruby_wasm/build_system/product/product.rb
@@ -1,9 +1,5 @@
-require "rake"
-
 module RubyWasm
   class BuildProduct
-    include Rake::DSL
-
     def name
       raise NotImplementedError, "identifiable product name must be implemented"
     end

--- a/lib/ruby_wasm/build_system/product/wasi_vfs.rb
+++ b/lib/ruby_wasm/build_system/product/wasi_vfs.rb
@@ -41,7 +41,7 @@ module RubyWasm
     end
 
     def build
-      return if !@need_fetch_lib && File.exist?(lib_wasi_vfs_a)
+      return if !@need_fetch_lib || File.exist?(lib_wasi_vfs_a)
       require "tmpdir"
       lib_wasi_vfs_url =
         "https://github.com/kateinoigakukun/wasi-vfs/releases/download/v#{WASI_VFS_VERSION}/libwasi_vfs-wasm32-unknown-unknown.zip"
@@ -54,7 +54,7 @@ module RubyWasm
     end
 
     def install_cli
-      return if !@need_fetch_cli && File.exist?(cli_bin_path)
+      return if !@need_fetch_cli || File.exist?(cli_bin_path)
       FileUtils.mkdir_p cli_product_build_dir
       zipfile = File.join(cli_product_build_dir, "wasi-vfs-cli.zip")
       system "curl -L -o #{zipfile} #{self.cli_download_url}"

--- a/lib/ruby_wasm/build_system/product/zlib.rb
+++ b/lib/ruby_wasm/build_system/product/zlib.rb
@@ -1,9 +1,8 @@
-require "rake"
 require_relative "./product"
 
 module RubyWasm
   class ZlibProduct < AutoconfProduct
-    attr_reader :target, :install_task
+    attr_reader :target
 
     ZLIB_VERSION = "1.2.13"
 
@@ -29,21 +28,18 @@ module RubyWasm
       product_build_dir
     end
 
-    def define_task
-      @install_task =
-        task name => [@toolchain.define_task] do
-          next if Dir.exist?(install_root)
+    def build
+      return if Dir.exist?(install_root)
 
-          mkdir_p File.dirname(product_build_dir)
-          rm_rf product_build_dir
+      FileUtils.mkdir_p File.dirname(product_build_dir)
+      FileUtils.rm_rf product_build_dir
 
-          sh "curl -L https://zlib.net/zlib-#{ZLIB_VERSION}.tar.gz | tar xz",
+      system "curl -L https://zlib.net/zlib-#{ZLIB_VERSION}.tar.gz | tar xz",
              chdir: File.dirname(product_build_dir)
 
-          sh "#{tools_args.join(" ")} ./configure --static",
+      system "#{tools_args.join(" ")} ./configure --static",
              chdir: product_build_dir
-          sh "make install DESTDIR=#{destdir}", chdir: product_build_dir
-        end
+      system "make install DESTDIR=#{destdir}", chdir: product_build_dir
     end
   end
 end

--- a/lib/ruby_wasm/build_system/toolchain/wit_bindgen.rb
+++ b/lib/ruby_wasm/build_system/toolchain/wit_bindgen.rb
@@ -12,26 +12,20 @@ module RubyWasm
       @revision = revision
     end
 
-    def define_task
-      file @bin_path do
-        RubyWasm::Toolchain.check_executable("cargo")
-        sh *[
-             "cargo",
-             "install",
-             "--git",
-             "https://github.com/bytecodealliance/wit-bindgen",
-             "--rev",
-             @revision,
-             "--root",
-             @tool_dir,
-             "wit-bindgen-cli"
-           ]
-      end
-      @task ||= task "wit-bindgen:install" => @bin_path
-    end
-
-    def install_task
-      @task
+    def install
+      return if File.exist?(@bin_path)
+      RubyWasm::Toolchain.check_executable("cargo")
+      system *[
+               "cargo",
+               "install",
+               "--git",
+               "https://github.com/bytecodealliance/wit-bindgen",
+               "--rev",
+               @revision,
+               "--root",
+               @tool_dir,
+               "wit-bindgen-cli"
+             ]
     end
   end
 end

--- a/lib/ruby_wasm/rake_task.rb
+++ b/lib/ruby_wasm/rake_task.rb
@@ -43,8 +43,7 @@ class RubyWasm::BuildTask < ::Rake::TaskLib
     @toolchain =
       add_product (toolchain || RubyWasm::Toolchain.get(target, @build_dir))
 
-    @libyaml =
-      add_product RubyWasm::LibYAMLProduct.new(@build_dir, @target, @toolchain)
+    @libyaml = RubyWasm::LibYAMLProduct.new(@build_dir, @target, @toolchain)
     @zlib =
       add_product RubyWasm::ZlibProduct.new(@build_dir, @target, @toolchain)
     @wasi_vfs = add_product RubyWasm::WasiVfsProduct.new(@build_dir)

--- a/lib/ruby_wasm/rake_task.rb
+++ b/lib/ruby_wasm/rake_task.rb
@@ -45,7 +45,7 @@ class RubyWasm::BuildTask < ::Rake::TaskLib
 
     @libyaml = RubyWasm::LibYAMLProduct.new(@build_dir, @target, @toolchain)
     @zlib = RubyWasm::ZlibProduct.new(@build_dir, @target, @toolchain)
-    @wasi_vfs = add_product RubyWasm::WasiVfsProduct.new(@build_dir)
+    @wasi_vfs = RubyWasm::WasiVfsProduct.new(@build_dir)
     @source = RubyWasm::BuildSource.new(src, @build_dir)
     @baseruby = RubyWasm::BaseRubyProduct.new(@build_dir, @source)
 

--- a/lib/ruby_wasm/rake_task.rb
+++ b/lib/ruby_wasm/rake_task.rb
@@ -48,7 +48,7 @@ class RubyWasm::BuildTask < ::Rake::TaskLib
     @zlib =
       add_product RubyWasm::ZlibProduct.new(@build_dir, @target, @toolchain)
     @wasi_vfs = add_product RubyWasm::WasiVfsProduct.new(@build_dir)
-    @source = add_product RubyWasm::BuildSource.new(src, @build_dir)
+    @source = RubyWasm::BuildSource.new(src, @build_dir)
     @baseruby = RubyWasm::BaseRubyProduct.new(@build_dir, @source)
 
     build_params =

--- a/lib/ruby_wasm/rake_task.rb
+++ b/lib/ruby_wasm/rake_task.rb
@@ -40,8 +40,7 @@ class RubyWasm::BuildTask < ::Rake::TaskLib
     @target = target
     @build_dir = build_dir || File.join(Dir.pwd, "build")
     @rubies_dir = rubies_dir || File.join(Dir.pwd, "rubies")
-    @toolchain =
-      add_product (toolchain || RubyWasm::Toolchain.get(target, @build_dir))
+    @toolchain = (toolchain || RubyWasm::Toolchain.get(target, @build_dir))
 
     @libyaml = RubyWasm::LibYAMLProduct.new(@build_dir, @target, @toolchain)
     @zlib = RubyWasm::ZlibProduct.new(@build_dir, @target, @toolchain)

--- a/lib/ruby_wasm/rake_task.rb
+++ b/lib/ruby_wasm/rake_task.rb
@@ -62,8 +62,6 @@ class RubyWasm::BuildTask < ::Rake::TaskLib
       )
     yield self if block_given?
 
-    @products_to_define&.each(&:define_task)
-
     @crossruby.with_libyaml @libyaml
     @crossruby.with_zlib @zlib
     @crossruby.with_wasi_vfs @wasi_vfs
@@ -95,16 +93,5 @@ class RubyWasm::BuildTask < ::Rake::TaskLib
     digest << @zlib.name
     digest << @wasi_vfs.name
     digest.hexdigest
-  end
-
-  private
-
-  def add_product(product)
-    @@products ||= {}
-    return @@products[product.name] if @@products[product.name]
-    @@products[product.name] = product
-    @products_to_define ||= []
-    @products_to_define << product
-    product
   end
 end

--- a/lib/ruby_wasm/rake_task.rb
+++ b/lib/ruby_wasm/rake_task.rb
@@ -49,7 +49,7 @@ class RubyWasm::BuildTask < ::Rake::TaskLib
       add_product RubyWasm::ZlibProduct.new(@build_dir, @target, @toolchain)
     @wasi_vfs = add_product RubyWasm::WasiVfsProduct.new(@build_dir)
     @source = add_product RubyWasm::BuildSource.new(src, @build_dir)
-    @baseruby = add_product RubyWasm::BaseRubyProduct.new(@build_dir, @source)
+    @baseruby = RubyWasm::BaseRubyProduct.new(@build_dir, @source)
 
     build_params =
       RubyWasm::BuildParams.new(options.merge(name: name, target: @target))

--- a/lib/ruby_wasm/rake_task.rb
+++ b/lib/ruby_wasm/rake_task.rb
@@ -44,8 +44,7 @@ class RubyWasm::BuildTask < ::Rake::TaskLib
       add_product (toolchain || RubyWasm::Toolchain.get(target, @build_dir))
 
     @libyaml = RubyWasm::LibYAMLProduct.new(@build_dir, @target, @toolchain)
-    @zlib =
-      add_product RubyWasm::ZlibProduct.new(@build_dir, @target, @toolchain)
+    @zlib = RubyWasm::ZlibProduct.new(@build_dir, @target, @toolchain)
     @wasi_vfs = add_product RubyWasm::WasiVfsProduct.new(@build_dir)
     @source = RubyWasm::BuildSource.new(src, @build_dir)
     @baseruby = RubyWasm::BaseRubyProduct.new(@build_dir, @source)

--- a/tasks/check.rake
+++ b/tasks/check.rake
@@ -1,7 +1,7 @@
 namespace :check do
   wit_bindgen = RubyWasm::WitBindgen.new(build_dir: "build")
-  wit_bindgen.define_task
-  task :bindgen_c => wit_bindgen.install_task do
+  task :bindgen_c do
+    wit_bindgen.install
     wits = [
       ["ext/witapi/bindgen/rb-abi-guest.wit", "--export"],
       ["ext/js/bindgen/rb-js-abi-host.wit", "--import"],
@@ -12,7 +12,8 @@ namespace :check do
     end
   end
 
-  task :bindgen_js => wit_bindgen.install_task do
+  task :bindgen_js do
+    wit_bindgen.install
     sh *[
       wit_bindgen.bin_path, "host", "js",
       "--import", "ext/witapi/bindgen/rb-abi-guest.wit",

--- a/tasks/packaging.rake
+++ b/tasks/packaging.rake
@@ -10,7 +10,6 @@ WAPM_PACKAGES = [
 
 namespace :npm do
   wasi_vfs = RubyWasm::WasiVfsProduct.new("build")
-  wasi_vfs.define_task
   wasi_sdk = TOOLCHAINS["wasi-sdk"]
   tools = {
     "WASI_VFS_CLI" => wasi_vfs.cli_bin_path,
@@ -21,7 +20,8 @@ namespace :npm do
     pkg_dir = "#{Dir.pwd}/packages/npm-packages/#{pkg[:name]}"
 
     desc "Build npm package #{pkg[:name]}"
-    task pkg[:name] => ["build:#{pkg[:build]}", wasi_vfs.cli_install_task, wasi_sdk.binaryen_install_task] do
+    task pkg[:name] => ["build:#{pkg[:build]}", wasi_sdk.binaryen_install_task] do
+      wasi_vfs.install_cli
       sh "npm ci", chdir: pkg_dir
       sh tools, "#{pkg_dir}/build-package.sh #{base_dir}/rubies/#{pkg[:build]}"
       sh "npm pack", chdir: pkg_dir

--- a/tasks/packaging.rake
+++ b/tasks/packaging.rake
@@ -20,8 +20,9 @@ namespace :npm do
     pkg_dir = "#{Dir.pwd}/packages/npm-packages/#{pkg[:name]}"
 
     desc "Build npm package #{pkg[:name]}"
-    task pkg[:name] => ["build:#{pkg[:build]}", wasi_sdk.binaryen_install_task] do
+    task pkg[:name] => ["build:#{pkg[:build]}"] do
       wasi_vfs.install_cli
+      wasi_sdk.install_binaryen
       sh "npm ci", chdir: pkg_dir
       sh tools, "#{pkg_dir}/build-package.sh #{base_dir}/rubies/#{pkg[:build]}"
       sh "npm pack", chdir: pkg_dir


### PR DESCRIPTION
Because most tasks are sequential and adopting rake added complexity, so drop the dependency from `lib/ruby_wasm/build_system`