### PR TITLE
Add JS::Error class to catch JS exception

### DIFF
--- a/ext/js/bindgen/rb-js-abi-host.c
+++ b/ext/js/bindgen/rb-js-abi-host.c
@@ -47,6 +47,18 @@ void rb_js_abi_host_string_free(rb_js_abi_host_string_t *ret) {
   ret->ptr = NULL;
   ret->len = 0;
 }
+void rb_js_abi_host_js_abi_result_free(rb_js_abi_host_js_abi_result_t *ptr) {
+  switch ((int32_t) ptr->tag) {
+    case 0: {
+      rb_js_abi_host_js_abi_value_free(&ptr->val.success);
+      break;
+    }
+    case 1: {
+      rb_js_abi_host_js_abi_value_free(&ptr->val.failure);
+      break;
+    }
+  }
+}
 void rb_js_abi_host_raw_integer_free(rb_js_abi_host_raw_integer_t *ptr) {
   switch ((int32_t) ptr->tag) {
     case 1: {
@@ -63,11 +75,27 @@ void rb_js_abi_host_list_js_abi_value_free(rb_js_abi_host_list_js_abi_value_t *p
     free(ptr->ptr);
   }
 }
-__attribute__((import_module("rb-js-abi-host"), import_name("eval-js: func(code: string) -> handle<js-abi-value>")))
-int32_t __wasm_import_rb_js_abi_host_eval_js(int32_t, int32_t);
-rb_js_abi_host_js_abi_value_t rb_js_abi_host_eval_js(rb_js_abi_host_string_t *code) {
-  int32_t ret = __wasm_import_rb_js_abi_host_eval_js((int32_t) (*code).ptr, (int32_t) (*code).len);
-  return (rb_js_abi_host_js_abi_value_t){ ret };
+__attribute__((import_module("rb-js-abi-host"), import_name("eval-js: func(code: string) -> variant { success(handle<js-abi-value>), failure(handle<js-abi-value>) }")))
+void __wasm_import_rb_js_abi_host_eval_js(int32_t, int32_t, int32_t);
+void rb_js_abi_host_eval_js(rb_js_abi_host_string_t *code, rb_js_abi_host_js_abi_result_t *ret0) {
+  
+  __attribute__((aligned(4)))
+  uint8_t ret_area[8];
+  int32_t ptr = (int32_t) &ret_area;
+  __wasm_import_rb_js_abi_host_eval_js((int32_t) (*code).ptr, (int32_t) (*code).len, ptr);
+  rb_js_abi_host_js_abi_result_t variant;
+  variant.tag = (int32_t) (*((uint8_t*) (ptr + 0)));
+  switch ((int32_t) variant.tag) {
+    case 0: {
+      variant.val.success = (rb_js_abi_host_js_abi_value_t){ *((int32_t*) (ptr + 4)) };
+      break;
+    }
+    case 1: {
+      variant.val.failure = (rb_js_abi_host_js_abi_value_t){ *((int32_t*) (ptr + 4)) };
+      break;
+    }
+  }
+  *ret0 = variant;
 }
 __attribute__((import_module("rb-js-abi-host"), import_name("is-js: func(value: handle<js-abi-value>) -> bool")))
 int32_t __wasm_import_rb_js_abi_host_is_js(int32_t);
@@ -182,11 +210,27 @@ bool rb_js_abi_host_js_value_strictly_equal(rb_js_abi_host_js_abi_value_t lhs, r
   int32_t ret = __wasm_import_rb_js_abi_host_js_value_strictly_equal((lhs).idx, (rhs).idx);
   return ret;
 }
-__attribute__((import_module("rb-js-abi-host"), import_name("reflect-apply: func(target: handle<js-abi-value>, this-argument: handle<js-abi-value>, arguments: list<handle<js-abi-value>>) -> handle<js-abi-value>")))
-int32_t __wasm_import_rb_js_abi_host_reflect_apply(int32_t, int32_t, int32_t, int32_t);
-rb_js_abi_host_js_abi_value_t rb_js_abi_host_reflect_apply(rb_js_abi_host_js_abi_value_t target, rb_js_abi_host_js_abi_value_t this_argument, rb_js_abi_host_list_js_abi_value_t *arguments) {
-  int32_t ret = __wasm_import_rb_js_abi_host_reflect_apply((target).idx, (this_argument).idx, (int32_t) (*arguments).ptr, (int32_t) (*arguments).len);
-  return (rb_js_abi_host_js_abi_value_t){ ret };
+__attribute__((import_module("rb-js-abi-host"), import_name("reflect-apply: func(target: handle<js-abi-value>, this-argument: handle<js-abi-value>, arguments: list<handle<js-abi-value>>) -> variant { success(handle<js-abi-value>), failure(handle<js-abi-value>) }")))
+void __wasm_import_rb_js_abi_host_reflect_apply(int32_t, int32_t, int32_t, int32_t, int32_t);
+void rb_js_abi_host_reflect_apply(rb_js_abi_host_js_abi_value_t target, rb_js_abi_host_js_abi_value_t this_argument, rb_js_abi_host_list_js_abi_value_t *arguments, rb_js_abi_host_js_abi_result_t *ret0) {
+  
+  __attribute__((aligned(4)))
+  uint8_t ret_area[8];
+  int32_t ptr = (int32_t) &ret_area;
+  __wasm_import_rb_js_abi_host_reflect_apply((target).idx, (this_argument).idx, (int32_t) (*arguments).ptr, (int32_t) (*arguments).len, ptr);
+  rb_js_abi_host_js_abi_result_t variant;
+  variant.tag = (int32_t) (*((uint8_t*) (ptr + 0)));
+  switch ((int32_t) variant.tag) {
+    case 0: {
+      variant.val.success = (rb_js_abi_host_js_abi_value_t){ *((int32_t*) (ptr + 4)) };
+      break;
+    }
+    case 1: {
+      variant.val.failure = (rb_js_abi_host_js_abi_value_t){ *((int32_t*) (ptr + 4)) };
+      break;
+    }
+  }
+  *ret0 = variant;
 }
 __attribute__((import_module("rb-js-abi-host"), import_name("reflect-construct: func(target: handle<js-abi-value>, arguments: list<handle<js-abi-value>>) -> handle<js-abi-value>")))
 int32_t __wasm_import_rb_js_abi_host_reflect_construct(int32_t, int32_t, int32_t);

--- a/ext/js/bindgen/rb-js-abi-host.c
+++ b/ext/js/bindgen/rb-js-abi-host.c
@@ -244,11 +244,27 @@ bool rb_js_abi_host_reflect_delete_property(rb_js_abi_host_js_abi_value_t target
   int32_t ret = __wasm_import_rb_js_abi_host_reflect_delete_property((target).idx, (int32_t) (*property_key).ptr, (int32_t) (*property_key).len);
   return ret;
 }
-__attribute__((import_module("rb-js-abi-host"), import_name("reflect-get: func(target: handle<js-abi-value>, property-key: string) -> handle<js-abi-value>")))
-int32_t __wasm_import_rb_js_abi_host_reflect_get(int32_t, int32_t, int32_t);
-rb_js_abi_host_js_abi_value_t rb_js_abi_host_reflect_get(rb_js_abi_host_js_abi_value_t target, rb_js_abi_host_string_t *property_key) {
-  int32_t ret = __wasm_import_rb_js_abi_host_reflect_get((target).idx, (int32_t) (*property_key).ptr, (int32_t) (*property_key).len);
-  return (rb_js_abi_host_js_abi_value_t){ ret };
+__attribute__((import_module("rb-js-abi-host"), import_name("reflect-get: func(target: handle<js-abi-value>, property-key: string) -> variant { success(handle<js-abi-value>), failure(handle<js-abi-value>) }")))
+void __wasm_import_rb_js_abi_host_reflect_get(int32_t, int32_t, int32_t, int32_t);
+void rb_js_abi_host_reflect_get(rb_js_abi_host_js_abi_value_t target, rb_js_abi_host_string_t *property_key, rb_js_abi_host_js_abi_result_t *ret0) {
+  
+  __attribute__((aligned(4)))
+  uint8_t ret_area[8];
+  int32_t ptr = (int32_t) &ret_area;
+  __wasm_import_rb_js_abi_host_reflect_get((target).idx, (int32_t) (*property_key).ptr, (int32_t) (*property_key).len, ptr);
+  rb_js_abi_host_js_abi_result_t variant;
+  variant.tag = (int32_t) (*((uint8_t*) (ptr + 0)));
+  switch ((int32_t) variant.tag) {
+    case 0: {
+      variant.val.success = (rb_js_abi_host_js_abi_value_t){ *((int32_t*) (ptr + 4)) };
+      break;
+    }
+    case 1: {
+      variant.val.failure = (rb_js_abi_host_js_abi_value_t){ *((int32_t*) (ptr + 4)) };
+      break;
+    }
+  }
+  *ret0 = variant;
 }
 __attribute__((import_module("rb-js-abi-host"), import_name("reflect-get-own-property-descriptor: func(target: handle<js-abi-value>, property-key: string) -> handle<js-abi-value>")))
 int32_t __wasm_import_rb_js_abi_host_reflect_get_own_property_descriptor(int32_t, int32_t, int32_t);
@@ -290,11 +306,27 @@ bool rb_js_abi_host_reflect_prevent_extensions(rb_js_abi_host_js_abi_value_t tar
   int32_t ret = __wasm_import_rb_js_abi_host_reflect_prevent_extensions((target).idx);
   return ret;
 }
-__attribute__((import_module("rb-js-abi-host"), import_name("reflect-set: func(target: handle<js-abi-value>, property-key: string, value: handle<js-abi-value>) -> bool")))
-int32_t __wasm_import_rb_js_abi_host_reflect_set(int32_t, int32_t, int32_t, int32_t);
-bool rb_js_abi_host_reflect_set(rb_js_abi_host_js_abi_value_t target, rb_js_abi_host_string_t *property_key, rb_js_abi_host_js_abi_value_t value) {
-  int32_t ret = __wasm_import_rb_js_abi_host_reflect_set((target).idx, (int32_t) (*property_key).ptr, (int32_t) (*property_key).len, (value).idx);
-  return ret;
+__attribute__((import_module("rb-js-abi-host"), import_name("reflect-set: func(target: handle<js-abi-value>, property-key: string, value: handle<js-abi-value>) -> variant { success(handle<js-abi-value>), failure(handle<js-abi-value>) }")))
+void __wasm_import_rb_js_abi_host_reflect_set(int32_t, int32_t, int32_t, int32_t, int32_t);
+void rb_js_abi_host_reflect_set(rb_js_abi_host_js_abi_value_t target, rb_js_abi_host_string_t *property_key, rb_js_abi_host_js_abi_value_t value, rb_js_abi_host_js_abi_result_t *ret0) {
+  
+  __attribute__((aligned(4)))
+  uint8_t ret_area[8];
+  int32_t ptr = (int32_t) &ret_area;
+  __wasm_import_rb_js_abi_host_reflect_set((target).idx, (int32_t) (*property_key).ptr, (int32_t) (*property_key).len, (value).idx, ptr);
+  rb_js_abi_host_js_abi_result_t variant;
+  variant.tag = (int32_t) (*((uint8_t*) (ptr + 0)));
+  switch ((int32_t) variant.tag) {
+    case 0: {
+      variant.val.success = (rb_js_abi_host_js_abi_value_t){ *((int32_t*) (ptr + 4)) };
+      break;
+    }
+    case 1: {
+      variant.val.failure = (rb_js_abi_host_js_abi_value_t){ *((int32_t*) (ptr + 4)) };
+      break;
+    }
+  }
+  *ret0 = variant;
 }
 __attribute__((import_module("rb-js-abi-host"), import_name("reflect-set-prototype-of: func(target: handle<js-abi-value>, prototype: handle<js-abi-value>) -> bool")))
 int32_t __wasm_import_rb_js_abi_host_reflect_set_prototype_of(int32_t, int32_t);

--- a/ext/js/bindgen/rb-js-abi-host.h
+++ b/ext/js/bindgen/rb-js-abi-host.h
@@ -25,6 +25,16 @@ extern "C"
   typedef struct {
     uint8_t tag;
     union {
+      rb_js_abi_host_js_abi_value_t success;
+      rb_js_abi_host_js_abi_value_t failure;
+    } val;
+  } rb_js_abi_host_js_abi_result_t;
+  #define RB_JS_ABI_HOST_JS_ABI_RESULT_SUCCESS 0
+  #define RB_JS_ABI_HOST_JS_ABI_RESULT_FAILURE 1
+  void rb_js_abi_host_js_abi_result_free(rb_js_abi_host_js_abi_result_t *ptr);
+  typedef struct {
+    uint8_t tag;
+    union {
       double f64;
       rb_js_abi_host_string_t bignum;
     } val;
@@ -37,7 +47,7 @@ extern "C"
     size_t len;
   } rb_js_abi_host_list_js_abi_value_t;
   void rb_js_abi_host_list_js_abi_value_free(rb_js_abi_host_list_js_abi_value_t *ptr);
-  rb_js_abi_host_js_abi_value_t rb_js_abi_host_eval_js(rb_js_abi_host_string_t *code);
+  void rb_js_abi_host_eval_js(rb_js_abi_host_string_t *code, rb_js_abi_host_js_abi_result_t *ret0);
   bool rb_js_abi_host_is_js(rb_js_abi_host_js_abi_value_t value);
   bool rb_js_abi_host_instance_of(rb_js_abi_host_js_abi_value_t value, rb_js_abi_host_js_abi_value_t klass);
   rb_js_abi_host_js_abi_value_t rb_js_abi_host_global_this(void);
@@ -53,7 +63,7 @@ extern "C"
   void rb_js_abi_host_js_value_typeof(rb_js_abi_host_js_abi_value_t value, rb_js_abi_host_string_t *ret0);
   bool rb_js_abi_host_js_value_equal(rb_js_abi_host_js_abi_value_t lhs, rb_js_abi_host_js_abi_value_t rhs);
   bool rb_js_abi_host_js_value_strictly_equal(rb_js_abi_host_js_abi_value_t lhs, rb_js_abi_host_js_abi_value_t rhs);
-  rb_js_abi_host_js_abi_value_t rb_js_abi_host_reflect_apply(rb_js_abi_host_js_abi_value_t target, rb_js_abi_host_js_abi_value_t this_argument, rb_js_abi_host_list_js_abi_value_t *arguments);
+  void rb_js_abi_host_reflect_apply(rb_js_abi_host_js_abi_value_t target, rb_js_abi_host_js_abi_value_t this_argument, rb_js_abi_host_list_js_abi_value_t *arguments, rb_js_abi_host_js_abi_result_t *ret0);
   rb_js_abi_host_js_abi_value_t rb_js_abi_host_reflect_construct(rb_js_abi_host_js_abi_value_t target, rb_js_abi_host_list_js_abi_value_t *arguments);
   bool rb_js_abi_host_reflect_delete_property(rb_js_abi_host_js_abi_value_t target, rb_js_abi_host_string_t *property_key);
   rb_js_abi_host_js_abi_value_t rb_js_abi_host_reflect_get(rb_js_abi_host_js_abi_value_t target, rb_js_abi_host_string_t *property_key);

--- a/ext/js/bindgen/rb-js-abi-host.h
+++ b/ext/js/bindgen/rb-js-abi-host.h
@@ -66,14 +66,14 @@ extern "C"
   void rb_js_abi_host_reflect_apply(rb_js_abi_host_js_abi_value_t target, rb_js_abi_host_js_abi_value_t this_argument, rb_js_abi_host_list_js_abi_value_t *arguments, rb_js_abi_host_js_abi_result_t *ret0);
   rb_js_abi_host_js_abi_value_t rb_js_abi_host_reflect_construct(rb_js_abi_host_js_abi_value_t target, rb_js_abi_host_list_js_abi_value_t *arguments);
   bool rb_js_abi_host_reflect_delete_property(rb_js_abi_host_js_abi_value_t target, rb_js_abi_host_string_t *property_key);
-  rb_js_abi_host_js_abi_value_t rb_js_abi_host_reflect_get(rb_js_abi_host_js_abi_value_t target, rb_js_abi_host_string_t *property_key);
+  void rb_js_abi_host_reflect_get(rb_js_abi_host_js_abi_value_t target, rb_js_abi_host_string_t *property_key, rb_js_abi_host_js_abi_result_t *ret0);
   rb_js_abi_host_js_abi_value_t rb_js_abi_host_reflect_get_own_property_descriptor(rb_js_abi_host_js_abi_value_t target, rb_js_abi_host_string_t *property_key);
   rb_js_abi_host_js_abi_value_t rb_js_abi_host_reflect_get_prototype_of(rb_js_abi_host_js_abi_value_t target);
   bool rb_js_abi_host_reflect_has(rb_js_abi_host_js_abi_value_t target, rb_js_abi_host_string_t *property_key);
   bool rb_js_abi_host_reflect_is_extensible(rb_js_abi_host_js_abi_value_t target);
   void rb_js_abi_host_reflect_own_keys(rb_js_abi_host_js_abi_value_t target, rb_js_abi_host_list_js_abi_value_t *ret0);
   bool rb_js_abi_host_reflect_prevent_extensions(rb_js_abi_host_js_abi_value_t target);
-  bool rb_js_abi_host_reflect_set(rb_js_abi_host_js_abi_value_t target, rb_js_abi_host_string_t *property_key, rb_js_abi_host_js_abi_value_t value);
+  void rb_js_abi_host_reflect_set(rb_js_abi_host_js_abi_value_t target, rb_js_abi_host_string_t *property_key, rb_js_abi_host_js_abi_value_t value, rb_js_abi_host_js_abi_result_t *ret0);
   bool rb_js_abi_host_reflect_set_prototype_of(rb_js_abi_host_js_abi_value_t target, rb_js_abi_host_js_abi_value_t prototype);
   #ifdef __cplusplus
 }

--- a/ext/js/bindgen/rb-js-abi-host.wit
+++ b/ext/js/bindgen/rb-js-abi-host.wit
@@ -1,6 +1,11 @@
 resource js-abi-value
 
-eval-js: func(code: string) -> js-abi-value
+variant js-abi-result {
+    success(js-abi-value),
+    failure(js-abi-value),
+}
+
+eval-js: func(code: string) -> js-abi-result
 is-js: func(value: js-abi-value) -> bool
 instance-of: func(value: js-abi-value, klass: js-abi-value) -> bool
 global-this: func() -> js-abi-value
@@ -27,7 +32,7 @@ js-value-typeof: func(value: js-abi-value) -> string
 js-value-equal: func(lhs: js-abi-value, rhs: js-abi-value) -> bool
 js-value-strictly-equal: func(lhs: js-abi-value, rhs: js-abi-value) -> bool
 
-reflect-apply: func(target: js-abi-value, this-argument: js-abi-value, arguments: list<js-abi-value>) -> js-abi-value
+reflect-apply: func(target: js-abi-value, this-argument: js-abi-value, arguments: list<js-abi-value>) -> js-abi-result
 reflect-construct: func(target: js-abi-value, arguments: list<js-abi-value>) -> js-abi-value
 reflect-delete-property: func(target: js-abi-value, property-key: string) -> bool
 reflect-get: func(target: js-abi-value, property-key: string) -> js-abi-value

--- a/ext/js/bindgen/rb-js-abi-host.wit
+++ b/ext/js/bindgen/rb-js-abi-host.wit
@@ -35,12 +35,12 @@ js-value-strictly-equal: func(lhs: js-abi-value, rhs: js-abi-value) -> bool
 reflect-apply: func(target: js-abi-value, this-argument: js-abi-value, arguments: list<js-abi-value>) -> js-abi-result
 reflect-construct: func(target: js-abi-value, arguments: list<js-abi-value>) -> js-abi-value
 reflect-delete-property: func(target: js-abi-value, property-key: string) -> bool
-reflect-get: func(target: js-abi-value, property-key: string) -> js-abi-value
+reflect-get: func(target: js-abi-value, property-key: string) -> js-abi-result
 reflect-get-own-property-descriptor: func(target: js-abi-value, property-key: string) -> js-abi-value
 reflect-get-prototype-of: func(target: js-abi-value) -> js-abi-value
 reflect-has: func(target: js-abi-value, property-key: string) -> bool
 reflect-is-extensible: func(target: js-abi-value) -> bool
 reflect-own-keys: func(target: js-abi-value) -> list<js-abi-value>
 reflect-prevent-extensions: func(target: js-abi-value) -> bool
-reflect-set: func(target: js-abi-value, property-key: string, value: js-abi-value) -> bool
+reflect-set: func(target: js-abi-value, property-key: string, value: js-abi-value) -> js-abi-result
 reflect-set-prototype-of: func(target: js-abi-value, prototype: js-abi-value) -> bool

--- a/ext/js/js-core.c
+++ b/ext/js/js-core.c
@@ -77,7 +77,8 @@ static inline void rstring_to_abi_string(VALUE rstr,
   memcpy(abi_str->ptr, RSTRING_PTR(rstr), abi_str->len);
 }
 
-static inline void raise_js_error_if_failure(const rb_js_abi_host_js_abi_result_t *result) {
+static inline void
+raise_js_error_if_failure(const rb_js_abi_host_js_abi_result_t *result) {
   if (result->tag == RB_JS_ABI_HOST_JS_ABI_RESULT_FAILURE) {
     VALUE js_err = jsvalue_s_new(result->val.failure);
     VALUE rb_err = rb_class_new_instance(1, &js_err, rb_cJS_Error);

--- a/ext/js/js-core.c
+++ b/ext/js/js-core.c
@@ -180,7 +180,10 @@ static VALUE _rb_js_obj_aref(VALUE obj, VALUE key) {
   rb_js_abi_host_string_t key_abi_str;
   key = rb_obj_as_string(key);
   rstring_to_abi_string(key, &key_abi_str);
-  return jsvalue_s_new(rb_js_abi_host_reflect_get(p->abi, &key_abi_str));
+  rb_js_abi_host_js_abi_result_t ret;
+  rb_js_abi_host_reflect_get(p->abi, &key_abi_str, &ret);
+  raise_js_error_if_failure(&ret);
+  return jsvalue_s_new(ret.val.success);
 }
 
 /*
@@ -199,7 +202,10 @@ static VALUE _rb_js_obj_aset(VALUE obj, VALUE key, VALUE val) {
   rb_js_abi_host_string_t key_abi_str;
   key = rb_obj_as_string(key);
   rstring_to_abi_string(key, &key_abi_str);
-  rb_js_abi_host_reflect_set(p->abi, &key_abi_str, v->abi);
+  rb_js_abi_host_js_abi_result_t ret;
+  rb_js_abi_host_reflect_set(p->abi, &key_abi_str, v->abi, &ret);
+  raise_js_error_if_failure(&ret);
+  rb_js_abi_host_js_abi_value_free(&ret.val.success);
   RB_GC_GUARD(rv);
   return val;
 }

--- a/ext/js/lib/js.rb
+++ b/ext/js/lib/js.rb
@@ -31,3 +31,21 @@ class JS::Object
     self[sym].typeof == "function"
   end
 end
+
+# A wrapper class for JavaScript Error to allow the Error to be thrown in Ruby.
+class JS::Error
+  def initialize(exception)
+    @exception = exception
+    super
+  end
+
+  def message
+    stack = @exception[:stack]
+    if stack.typeof == "string"
+      # Error.stack contains the error message also
+      stack.to_s
+    else
+      @exception.to_s
+    end
+  end
+end

--- a/packages/npm-packages/ruby-wasm-wasi/src/bindgen/rb-js-abi-host.d.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/bindgen/rb-js-abi-host.d.ts
@@ -37,14 +37,14 @@ export interface RbJsAbiHost {
   reflectApply(target: JsAbiValue, thisArgument: JsAbiValue, arguments: JsAbiValue[]): JsAbiResult;
   reflectConstruct(target: JsAbiValue, arguments: JsAbiValue[]): JsAbiValue;
   reflectDeleteProperty(target: JsAbiValue, propertyKey: string): boolean;
-  reflectGet(target: JsAbiValue, propertyKey: string): JsAbiValue;
+  reflectGet(target: JsAbiValue, propertyKey: string): JsAbiResult;
   reflectGetOwnPropertyDescriptor(target: JsAbiValue, propertyKey: string): JsAbiValue;
   reflectGetPrototypeOf(target: JsAbiValue): JsAbiValue;
   reflectHas(target: JsAbiValue, propertyKey: string): boolean;
   reflectIsExtensible(target: JsAbiValue): boolean;
   reflectOwnKeys(target: JsAbiValue): JsAbiValue[];
   reflectPreventExtensions(target: JsAbiValue): boolean;
-  reflectSet(target: JsAbiValue, propertyKey: string, value: JsAbiValue): boolean;
+  reflectSet(target: JsAbiValue, propertyKey: string, value: JsAbiValue): JsAbiResult;
   reflectSetPrototypeOf(target: JsAbiValue, prototype: JsAbiValue): boolean;
   dropJsAbiValue?: (val: JsAbiValue) => void;
 }

--- a/packages/npm-packages/ruby-wasm-wasi/src/bindgen/rb-js-abi-host.d.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/bindgen/rb-js-abi-host.d.ts
@@ -1,3 +1,12 @@
+export type JsAbiResult = JsAbiResultSuccess | JsAbiResultFailure;
+export interface JsAbiResultSuccess {
+  tag: "success",
+  val: JsAbiValue,
+}
+export interface JsAbiResultFailure {
+  tag: "failure",
+  val: JsAbiValue,
+}
 export type RawInteger = RawIntegerF64 | RawIntegerBignum;
 export interface RawIntegerF64 {
   tag: "f64",
@@ -9,7 +18,7 @@ export interface RawIntegerBignum {
 }
 export function addRbJsAbiHostToImports(imports: any, obj: RbJsAbiHost, get_export: (name: string) => WebAssembly.ExportValue): void;
 export interface RbJsAbiHost {
-  evalJs(code: string): JsAbiValue;
+  evalJs(code: string): JsAbiResult;
   isJs(value: JsAbiValue): boolean;
   instanceOf(value: JsAbiValue, klass: JsAbiValue): boolean;
   globalThis(): JsAbiValue;
@@ -25,7 +34,7 @@ export interface RbJsAbiHost {
   jsValueTypeof(value: JsAbiValue): string;
   jsValueEqual(lhs: JsAbiValue, rhs: JsAbiValue): boolean;
   jsValueStrictlyEqual(lhs: JsAbiValue, rhs: JsAbiValue): boolean;
-  reflectApply(target: JsAbiValue, thisArgument: JsAbiValue, arguments: JsAbiValue[]): JsAbiValue;
+  reflectApply(target: JsAbiValue, thisArgument: JsAbiValue, arguments: JsAbiValue[]): JsAbiResult;
   reflectConstruct(target: JsAbiValue, arguments: JsAbiValue[]): JsAbiValue;
   reflectDeleteProperty(target: JsAbiValue, propertyKey: string): boolean;
   reflectGet(target: JsAbiValue, propertyKey: string): JsAbiValue;

--- a/packages/npm-packages/ruby-wasm-wasi/src/bindgen/rb-js-abi-host.js
+++ b/packages/npm-packages/ruby-wasm-wasi/src/bindgen/rb-js-abi-host.js
@@ -1,13 +1,29 @@
 import { data_view, UTF8_DECODER, utf8_encode, UTF8_ENCODED_LEN, Slab, throw_invalid_bool } from './intrinsics.js';
 export function addRbJsAbiHostToImports(imports, obj, get_export) {
   if (!("rb-js-abi-host" in imports)) imports["rb-js-abi-host"] = {};
-  imports["rb-js-abi-host"]["eval-js: func(code: string) -> handle<js-abi-value>"] = function(arg0, arg1) {
+  imports["rb-js-abi-host"]["eval-js: func(code: string) -> variant { success(handle<js-abi-value>), failure(handle<js-abi-value>) }"] = function(arg0, arg1, arg2) {
     const memory = get_export("memory");
     const ptr0 = arg0;
     const len0 = arg1;
     const result0 = UTF8_DECODER.decode(new Uint8Array(memory.buffer, ptr0, len0));
     const ret0 = obj.evalJs(result0);
-    return resources0.insert(ret0);
+    const variant1 = ret0;
+    switch (variant1.tag) {
+      case "success": {
+        const e = variant1.val;
+        data_view(memory).setInt8(arg2 + 0, 0, true);
+        data_view(memory).setInt32(arg2 + 4, resources0.insert(e), true);
+        break;
+      }
+      case "failure": {
+        const e = variant1.val;
+        data_view(memory).setInt8(arg2 + 0, 1, true);
+        data_view(memory).setInt32(arg2 + 4, resources0.insert(e), true);
+        break;
+      }
+      default:
+      throw new RangeError("invalid variant specified for JsAbiResult");
+    }
   };
   imports["rb-js-abi-host"]["is-js: func(value: handle<js-abi-value>) -> bool"] = function(arg0) {
     const ret0 = obj.isJs(resources0.get(arg0));
@@ -104,7 +120,7 @@ export function addRbJsAbiHostToImports(imports, obj, get_export) {
     const ret0 = obj.jsValueStrictlyEqual(resources0.get(arg0), resources0.get(arg1));
     return ret0 ? 1 : 0;
   };
-  imports["rb-js-abi-host"]["reflect-apply: func(target: handle<js-abi-value>, this-argument: handle<js-abi-value>, arguments: list<handle<js-abi-value>>) -> handle<js-abi-value>"] = function(arg0, arg1, arg2, arg3) {
+  imports["rb-js-abi-host"]["reflect-apply: func(target: handle<js-abi-value>, this-argument: handle<js-abi-value>, arguments: list<handle<js-abi-value>>) -> variant { success(handle<js-abi-value>), failure(handle<js-abi-value>) }"] = function(arg0, arg1, arg2, arg3, arg4) {
     const memory = get_export("memory");
     const len0 = arg3;
     const base0 = arg2;
@@ -114,7 +130,23 @@ export function addRbJsAbiHostToImports(imports, obj, get_export) {
       result0.push(resources0.get(data_view(memory).getInt32(base + 0, true)));
     }
     const ret0 = obj.reflectApply(resources0.get(arg0), resources0.get(arg1), result0);
-    return resources0.insert(ret0);
+    const variant1 = ret0;
+    switch (variant1.tag) {
+      case "success": {
+        const e = variant1.val;
+        data_view(memory).setInt8(arg4 + 0, 0, true);
+        data_view(memory).setInt32(arg4 + 4, resources0.insert(e), true);
+        break;
+      }
+      case "failure": {
+        const e = variant1.val;
+        data_view(memory).setInt8(arg4 + 0, 1, true);
+        data_view(memory).setInt32(arg4 + 4, resources0.insert(e), true);
+        break;
+      }
+      default:
+      throw new RangeError("invalid variant specified for JsAbiResult");
+    }
   };
   imports["rb-js-abi-host"]["reflect-construct: func(target: handle<js-abi-value>, arguments: list<handle<js-abi-value>>) -> handle<js-abi-value>"] = function(arg0, arg1, arg2) {
     const memory = get_export("memory");

--- a/packages/npm-packages/ruby-wasm-wasi/src/bindgen/rb-js-abi-host.js
+++ b/packages/npm-packages/ruby-wasm-wasi/src/bindgen/rb-js-abi-host.js
@@ -168,13 +168,29 @@ export function addRbJsAbiHostToImports(imports, obj, get_export) {
     const ret0 = obj.reflectDeleteProperty(resources0.get(arg0), result0);
     return ret0 ? 1 : 0;
   };
-  imports["rb-js-abi-host"]["reflect-get: func(target: handle<js-abi-value>, property-key: string) -> handle<js-abi-value>"] = function(arg0, arg1, arg2) {
+  imports["rb-js-abi-host"]["reflect-get: func(target: handle<js-abi-value>, property-key: string) -> variant { success(handle<js-abi-value>), failure(handle<js-abi-value>) }"] = function(arg0, arg1, arg2, arg3) {
     const memory = get_export("memory");
     const ptr0 = arg1;
     const len0 = arg2;
     const result0 = UTF8_DECODER.decode(new Uint8Array(memory.buffer, ptr0, len0));
     const ret0 = obj.reflectGet(resources0.get(arg0), result0);
-    return resources0.insert(ret0);
+    const variant1 = ret0;
+    switch (variant1.tag) {
+      case "success": {
+        const e = variant1.val;
+        data_view(memory).setInt8(arg3 + 0, 0, true);
+        data_view(memory).setInt32(arg3 + 4, resources0.insert(e), true);
+        break;
+      }
+      case "failure": {
+        const e = variant1.val;
+        data_view(memory).setInt8(arg3 + 0, 1, true);
+        data_view(memory).setInt32(arg3 + 4, resources0.insert(e), true);
+        break;
+      }
+      default:
+      throw new RangeError("invalid variant specified for JsAbiResult");
+    }
   };
   imports["rb-js-abi-host"]["reflect-get-own-property-descriptor: func(target: handle<js-abi-value>, property-key: string) -> handle<js-abi-value>"] = function(arg0, arg1, arg2) {
     const memory = get_export("memory");
@@ -219,13 +235,29 @@ export function addRbJsAbiHostToImports(imports, obj, get_export) {
     const ret0 = obj.reflectPreventExtensions(resources0.get(arg0));
     return ret0 ? 1 : 0;
   };
-  imports["rb-js-abi-host"]["reflect-set: func(target: handle<js-abi-value>, property-key: string, value: handle<js-abi-value>) -> bool"] = function(arg0, arg1, arg2, arg3) {
+  imports["rb-js-abi-host"]["reflect-set: func(target: handle<js-abi-value>, property-key: string, value: handle<js-abi-value>) -> variant { success(handle<js-abi-value>), failure(handle<js-abi-value>) }"] = function(arg0, arg1, arg2, arg3, arg4) {
     const memory = get_export("memory");
     const ptr0 = arg1;
     const len0 = arg2;
     const result0 = UTF8_DECODER.decode(new Uint8Array(memory.buffer, ptr0, len0));
     const ret0 = obj.reflectSet(resources0.get(arg0), result0, resources0.get(arg3));
-    return ret0 ? 1 : 0;
+    const variant1 = ret0;
+    switch (variant1.tag) {
+      case "success": {
+        const e = variant1.val;
+        data_view(memory).setInt8(arg4 + 0, 0, true);
+        data_view(memory).setInt32(arg4 + 4, resources0.insert(e), true);
+        break;
+      }
+      case "failure": {
+        const e = variant1.val;
+        data_view(memory).setInt8(arg4 + 0, 1, true);
+        data_view(memory).setInt32(arg4 + 4, resources0.insert(e), true);
+        break;
+      }
+      default:
+      throw new RangeError("invalid variant specified for JsAbiResult");
+    }
   };
   imports["rb-js-abi-host"]["reflect-set-prototype-of: func(target: handle<js-abi-value>, prototype: handle<js-abi-value>) -> bool"] = function(arg0, arg1) {
     const ret0 = obj.reflectSetPrototypeOf(resources0.get(arg0), resources0.get(arg1));

--- a/packages/npm-packages/ruby-wasm-wasi/src/browser.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/browser.ts
@@ -5,7 +5,12 @@ import { RubyVM } from "./index";
 export const DefaultRubyVM = async (
   rubyModule: WebAssembly.Module,
   options: { consolePrint: boolean } = { consolePrint: true }
-): Promise<{ vm: RubyVM, wasi: any, fs: any, instance: WebAssembly.Instance }> => {
+): Promise<{
+  vm: RubyVM;
+  wasi: any;
+  fs: any;
+  instance: WebAssembly.Instance;
+}> => {
   const wasmFs = new WasmFs();
   const wasi = new WASI({
     bindings: {

--- a/packages/npm-packages/ruby-wasm-wasi/src/index.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/index.ts
@@ -162,9 +162,9 @@ export class RubyVM {
         reflectDeleteProperty: function (target, propertyKey): boolean {
           throw new Error("Function not implemented.");
         },
-        reflectGet: function (target, propertyKey) {
+        reflectGet: wrapTry((target, propertyKey) => {
           return target[propertyKey];
-        },
+        }),
         reflectGetOwnPropertyDescriptor: function (
           target,
           propertyKey: string
@@ -186,9 +186,9 @@ export class RubyVM {
         reflectPreventExtensions: function (target): boolean {
           throw new Error("Function not implemented.");
         },
-        reflectSet: function (target, propertyKey, value): boolean {
+        reflectSet: wrapTry((target, propertyKey, value) => {
           return Reflect.set(target, propertyKey, value);
-        },
+        }),
         reflectSetPrototypeOf: function (target, prototype): boolean {
           throw new Error("Function not implemented.");
         },

--- a/packages/npm-packages/ruby-wasm-wasi/src/index.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/index.ts
@@ -1,5 +1,9 @@
 import * as RbAbi from "./bindgen/rb-abi-guest";
-import { addRbJsAbiHostToImports, JsAbiResult, JsAbiValue } from "./bindgen/rb-js-abi-host";
+import {
+  addRbJsAbiHostToImports,
+  JsAbiResult,
+  JsAbiValue,
+} from "./bindgen/rb-js-abi-host";
 
 /**
  * A Ruby VM instance
@@ -70,10 +74,10 @@ export class RubyVM {
         try {
           return { tag: "success", val: f(...args) };
         } catch (e) {
-          return { tag: "failure", val: e }
+          return { tag: "failure", val: e };
         }
-      }
-    };
+      };
+    }
     addRbJsAbiHostToImports(
       imports,
       {

--- a/packages/npm-packages/ruby-wasm-wasi/test/unit/test_error.rb
+++ b/packages/npm-packages/ruby-wasm-wasi/test/unit/test_error.rb
@@ -1,0 +1,20 @@
+require "test-unit"
+require "js"
+
+class JS::TestError < Test::Unit::TestCase
+  def test_throw_error
+    e = assert_raise(JS::Error) do
+      JS.eval("throw new Error('foo')")
+    end
+    assert_match /^Error: foo/, e.message
+    assert_equal "#<JS::Error: Error: foo>", e.inspect
+  end
+
+  def test_throw_non_error
+    e = assert_raise(JS::Error) do
+      JS.eval("throw 'foo'")
+    end
+    assert_equal "foo", e.message
+    assert_equal "#<JS::Error: foo>", e.inspect
+  end
+end

--- a/packages/npm-packages/ruby-wasm-wasi/test/unit/test_error.rb
+++ b/packages/npm-packages/ruby-wasm-wasi/test/unit/test_error.rb
@@ -3,17 +3,13 @@ require "js"
 
 class JS::TestError < Test::Unit::TestCase
   def test_throw_error
-    e = assert_raise(JS::Error) do
-      JS.eval("throw new Error('foo')")
-    end
+    e = assert_raise(JS::Error) { JS.eval("throw new Error('foo')") }
     assert_match /^Error: foo/, e.message
     assert_equal "#<JS::Error: Error: foo>", e.inspect
   end
 
   def test_throw_non_error
-    e = assert_raise(JS::Error) do
-      JS.eval("throw 'foo'")
-    end
+    e = assert_raise(JS::Error) { JS.eval("throw 'foo'") }
     assert_equal "foo", e.message
     assert_equal "#<JS::Error: foo>", e.inspect
   end

--- a/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
+++ b/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
@@ -202,6 +202,10 @@ class JS::TestObject < Test::Unit::TestCase
     JS
     assert_equal 42.to_s, object[:foo].to_s
     assert_equal 42.to_s, object["foo"].to_s
+
+    assert_raise(JS::Error) do
+      JS::Undefined[:foo]
+    end
   end
 
   def test_member_set
@@ -212,6 +216,10 @@ class JS::TestObject < Test::Unit::TestCase
     assert_equal 24.to_s, object[:foo].to_s
     object["foo"] = 42
     assert_equal 42.to_s, object["foo"].to_s
+
+    assert_raise(JS::Error) do
+      JS::Undefined[:foo] = 42
+    end
   end
 
   def test_member_set_with_stress_gc

--- a/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
+++ b/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
@@ -203,9 +203,7 @@ class JS::TestObject < Test::Unit::TestCase
     assert_equal 42.to_s, object[:foo].to_s
     assert_equal 42.to_s, object["foo"].to_s
 
-    assert_raise(JS::Error) do
-      JS::Undefined[:foo]
-    end
+    assert_raise(JS::Error) { JS::Undefined[:foo] }
   end
 
   def test_member_set
@@ -217,9 +215,7 @@ class JS::TestObject < Test::Unit::TestCase
     object["foo"] = 42
     assert_equal 42.to_s, object["foo"].to_s
 
-    assert_raise(JS::Error) do
-      JS::Undefined[:foo] = 42
-    end
+    assert_raise(JS::Error) { JS::Undefined[:foo] = 42 }
   end
 
   def test_member_set_with_stress_gc


### PR DESCRIPTION
| Before | After |
|:-:|:-:|
| <img width="1327" alt="Screen Shot 2022-11-05 at 14 05 45" src="https://user-images.githubusercontent.com/11702759/200102203-020bc586-de0f-4916-9c24-219a675e9ce0.png"> |  <img width="1327" alt="Screen Shot 2022-11-05 at 14 04 52" src="https://user-images.githubusercontent.com/11702759/200102196-03f43581-7053-4d65-9bb6-b4f848d80987.png"> |
