### PR TITLE
Update addEventListener to match new API from PR #36

### DIFF
--- a/ext/js/lib/js.rb
+++ b/ext/js/lib/js.rb
@@ -7,7 +7,7 @@ require "js.so"
 #   require 'js'
 #   JS.eval("return 1 + 2") # => 3
 #   JS.global[:document].write("Hello, world!")
-#   JS.global[:document].addEventListner("click") do |event|
+#   JS.global[:document].call :addEventListener, "click" ->(event) do |event|
 #     puts event          # => # [object MouseEvent]
 #     puts event[:detail] # => 1
 #   end

--- a/packages/npm-packages/ruby-wasm-wasi/example/lucky.html
+++ b/packages/npm-packages/ruby-wasm-wasi/example/lucky.html
@@ -7,7 +7,7 @@
     document = JS.global[:document]
     button = document.getElementById "draw"
     result = document.getElementById "result"
-    button.addEventListener "click" do |e|
+    button.call :addEventListener, 'click', ->(e) do
       p e
       luckiness = ["Lucky", "Unlucky"].sample
       result[:innerText] = luckiness


### PR DESCRIPTION
This updates the documentation for event listeners to match the new `call` and pass a `Proc` syntax.