### PR TITLE
Update js.rb doc comment

### DIFF
--- a/ext/js/lib/js.rb
+++ b/ext/js/lib/js.rb
@@ -7,9 +7,31 @@ require "js.so"
 #   require 'js'
 #   JS.eval("return 1 + 2") # => 3
 #   JS.global[:document].write("Hello, world!")
-#   JS.global[:document].addEventListner("click") do |event|
+#   div = JS.global[:document].createElement("div")
+#   div[:innerText] = "click me"
+#   JS.global[:document][:body].appendChild(div)
+#   div.addEventListener("click") do |event|
 #     puts event          # => # [object MouseEvent]
 #     puts event[:detail] # => 1
+#     div[:innerText] = "clicked!"
+#   end
+#
+# If you are using `ruby.wasm` without `stdlib` you will not have `addEventListener`
+# and other specialized functions defined. You can still acomplish many
+# of the same things using `call` instead.
+#
+# == Example
+#
+#   require 'js'
+#   JS.eval("return 1 + 2") # => 3
+#   JS.global[:document].call(:write, "Hello, world!")
+#   div = JS.global[:document].call(:createElement, "div")
+#   div[:innerText] = "click me"
+#   JS.global[:document][:body].call(:appendChild, div)
+#   div.call(:addEventListener, "click") do |event|
+#     puts event          # => # [object MouseEvent]
+#     puts event[:detail] # => 1
+#     div[:innerText] = "clicked!"
 #   end
 #
 module JS


### PR DESCRIPTION
Thanks for clearing up my confusion in https://github.com/ruby/ruby.wasm/pull/129
Here is a version of the doc comment that might help answer questions like mine in the future.

This change does several things,
- This fixes the typo in addEventListener
- Updates the document to call addEventListener on a class that defines it
- Adds an additional example for when using without stdlib