### PR TITLE
Default UTF-8

### DIFF
--- a/packages/npm-packages/ruby-wasm-wasi/src/index.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/index.ts
@@ -41,7 +41,9 @@ export class RubyVM {
    * @param args The command line arguments to pass to Ruby. Must be
    * an array of strings starting with the Ruby program name.
    */
-  initialize(args: string[] = ["ruby.wasm", "--disable-gems", "-e_=0"]) {
+  initialize(
+    args: string[] = ["ruby.wasm", "--disable-gems", "-EUTF-8", "-e_=0"]
+  ) {
     const c_args = args.map((arg) => arg + "\0");
     this.guest.rubyInit();
     this.guest.rubySysinit(c_args);

--- a/packages/npm-packages/ruby-wasm-wasi/test/vm.test.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/test/vm.test.ts
@@ -228,4 +228,10 @@ eval:11:in \`<main>'`);
     );
     expect(result.call("nil?").toString()).toBe("true");
   });
+
+  test("eval encoding", async () => {
+    const vm = await initRubyVM();
+    expect(vm.eval(`"hello".encoding.name`).toString()).toBe("UTF-8");
+    expect(vm.eval(`__ENCODING__.name`).toString()).toBe("UTF-8");
+  });
 });

--- a/packages/npm-packages/ruby-wasm-wasi/test/vm.test.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/test/vm.test.ts
@@ -231,6 +231,7 @@ eval:11:in \`<main>'`);
 
   test("eval encoding", async () => {
     const vm = await initRubyVM();
+    expect(vm.eval(`Encoding.default_external.name`).toString()).toBe("UTF-8");
     expect(vm.eval(`"hello".encoding.name`).toString()).toBe("UTF-8");
     expect(vm.eval(`__ENCODING__.name`).toString()).toBe("UTF-8");
   });


### PR DESCRIPTION
The public C API set of CRuby doesn't accept non-ASCII-8BIT string as eval contents. So script encoding was always ASCII-8BIT even though the eval content given by JS API can have non-ascii things.

This PR adds a new API to accept eval content as a `VALUE`, and use it in `witapi` ext. This implementation uses private symbols and type definitions, so very fragile. This should be upstreamed after bunch of experiments in this project. 