### PR TITLE
Fix `docker load` failure on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: builders/${{ matrix.entry.tag }}
-          outputs: type=oci,dest=/tmp/image.tar
+          outputs: type=docker,dest=/tmp/image.tar
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - name: Upload image artifact


### PR DESCRIPTION
`docker/build-push-action` or GHA runner's change may be related but I don't have enough time to investiage more.

- https://github.com/actions/runner-images/commit/794867863fdd7e3cda18c93a820a5bec90a39dda
- https://github.com/docker/build-push-action/commit/0cb700ffbacf264d97c1be9a9dbb41a7ddf3e6a3