### PR TITLE
Update base distribution version to update baseruby version

### DIFF
--- a/builders/wasm32-unknown-emscripten/Dockerfile
+++ b/builders/wasm32-unknown-emscripten/Dockerfile
@@ -1,4 +1,4 @@
-FROM emscripten/emsdk:2.0.13
+FROM emscripten/emsdk:3.1.31
 
 RUN set -eux; \
   apt-get update; \

--- a/builders/wasm32-unknown-wasi/Dockerfile
+++ b/builders/wasm32-unknown-wasi/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye
 
 ARG WASI_SDK_VERSION_MAJOR=14
 ARG WASI_SDK_VERSION_MINOR=0


### PR DESCRIPTION
The baseruby is used to bootstrap a baseruby of the version for which is cross-compiled.
Revealed by https://github.com/ruby/ruby/commit/8eaa346620c1699ee1c80e4e48c9689b019f334d