### PR TITLE
Set encoding of `JS::Object#to_s` result string to UTF-8

### DIFF
--- a/ext/js/js-core.c
+++ b/ext/js/js-core.c
@@ -341,7 +341,7 @@ static VALUE _rb_js_obj_to_s(VALUE obj) {
   struct jsvalue *p = check_jsvalue(obj);
   rb_js_abi_host_string_t ret0;
   rb_js_abi_host_js_value_to_string(p->abi, &ret0);
-  return rb_str_new(ret0.ptr, ret0.len);
+  return rb_utf8_str_new(ret0.ptr, ret0.len);
 }
 
 /*

--- a/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
+++ b/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
@@ -64,6 +64,11 @@ class JS::TestObject < Test::Unit::TestCase
     assert_equal "undefined", JS.eval("return undefined;").to_s
   end
 
+  def test_to_s_encoding
+    assert_equal Encoding::UTF_8, JS.eval("return 'str';").to_s.encoding
+    assert_equal Encoding::UTF_8, JS.eval("return 'あいうえお';").to_s.encoding
+  end
+
   def test_inspect
     assert_equal "str", JS.eval("return 'str';").to_s
     assert_equal "24", JS.eval("return 24;").inspect


### PR DESCRIPTION
A byte sequence of a string given by JS is encoded in UTF-8, so we want to be encoded in UTF-8 even in Ruby.