### PR TITLE
Fix download urls for arm64e

### DIFF
--- a/lib/ruby_wasm/build_system/product/wasi_vfs.rb
+++ b/lib/ruby_wasm/build_system/product/wasi_vfs.rb
@@ -65,7 +65,7 @@ module RubyWasm
       assets = [
         [/x86_64-linux/, "wasi-vfs-cli-x86_64-unknown-linux-gnu.zip"],
         [/x86_64-darwin/, "wasi-vfs-cli-x86_64-apple-darwin.zip"],
-        [/arm64-darwin/, "wasi-vfs-cli-aarch64-apple-darwin.zip"]
+        [/arm64e?-darwin/, "wasi-vfs-cli-aarch64-apple-darwin.zip"]
       ]
       asset = assets.find { |os, _| os =~ RUBY_PLATFORM }&.at(1)
       if asset.nil?

--- a/lib/ruby_wasm/build_system/toolchain.rb
+++ b/lib/ruby_wasm/build_system/toolchain.rb
@@ -127,7 +127,7 @@ module RubyWasm
           "binaryen-version_#{@binaryen_version}-x86_64-macos.tar.gz"
         ],
         [
-          /arm64-darwin/,
+          /arm64e?-darwin/,
           "binaryen-version_#{@binaryen_version}-arm64-macos.tar.gz"
         ]
       ]


### PR DESCRIPTION
Follow-up changes in d752bfc15ebb86b62af647daa26ad4d7e2c36219.

Without this fix, I saw the following error on my laptop (MacBook Pro 2021 M1):

```
unsupported platform for fetching wasi-vfs CLI: universal.arm64e-darwin22
```

and similar error message for binaryen.