### PR TITLE
Correct refspec to fetch Ruby source

### DIFF
--- a/lib/ruby_wasm/build_system/product/ruby_source.rb
+++ b/lib/ruby_wasm/build_system/product/ruby_source.rb
@@ -39,10 +39,10 @@ module RubyWasm
         system "git init", chdir: src_dir
         system "git remote add origin #{repo_url}", chdir: src_dir
         system(
-          "git fetch --depth 1 origin #{@params[:rev]}:#{@params[:rev]}",
+          "git fetch --depth 1 origin #{@params[:rev]}:origin/#{@params[:rev]}",
           chdir: src_dir
         ) or raise "failed to clone #{repo_url}"
-        system("git checkout #{@params[:rev]}", chdir: src_dir) or
+        system("git checkout origin/#{@params[:rev]}", chdir: src_dir) or
           raise "failed to checkout #{@params[:rev]}"
       when "local"
         FileUtils.mkdir_p File.dirname(src_dir)


### PR DESCRIPTION
`git fetch master:master` means synchronization of the remote `master` with the local `master`. If the local `master` is `HEAD`, Git will also try to update the file tree, but it is refused by default. Thus, we may see the errors like `fatal: Refusing to fetch into current branch refs/heads/master of non-bare repository`.

One of solutions is using `--update-head-ok` (`-u`) flag. It enforces to update the file tree on fetching `HEAD`. However, it seems not good to me because the Rake task uses `git checkout` after this `git fetch` so the file system updation on fetch is unnecessary.

Another solution, by using this, is correcting refspec so that destination part becomes `origin`. Presumably, this is the canonical fix method.

I'm not sure why the CI have been passed. Maybe GitHub returns a different (optimized) response on CI.