### PR TITLE
Is @is_spinning necessary?

### DIFF
--- a/ext/js/lib/js.rb
+++ b/ext/js/lib/js.rb
@@ -43,14 +43,12 @@ module JS
 
     def initialize(main_fiber)
       @tasks = []
-      @is_spinning = false
       @loop_fiber =
         Fiber.new do
           loop do
             while task = @tasks.shift
               task.fiber.transfer(task.value, task.status)
             end
-            @is_spinning = false
             main_fiber.transfer
           end
         end
@@ -70,10 +68,7 @@ module JS
 
     def enqueue(task)
       @tasks << task
-      unless @is_spinning
-        @is_spinning = true
-        JS.global.queueMicrotask -> { @loop_fiber.transfer }
-      end
+      JS.global.queueMicrotask -> { @loop_fiber.transfer }
     end
   end
 


### PR DESCRIPTION
View the following HTML in browser and press the Button:

```html
<!DOCTYPE html>
<html>
    <script src="https://cdn.jsdelivr.net/npm/ruby-3_2-wasm-wasi@1.0.1-2023-05-05-a/dist/browser.script.iife.js"></script>
    <body>
        <button id="button">Button</button>
        <script type="text/ruby">
         require 'js'
         def fuga(x)
             p [:fuga, x, :start]
             JS.global.fetch('hoge.html').await
             @q.pop
             JS.global[:document].getElementsByTagName('body')[0][:style][:background] = '' if @q.empty?
             p [:fuga, x, :end]
         end
         def hoge(x)
             p [:hoge, x, :start]
             @q.push 1
             JS.global[:document].getElementsByTagName('body')[0][:style][:background] = 'red'
             JS.global.fetch('hoge.html').await
             fuga(x)
             p [:hoge, x, :end]
         end
         @q = []
         JS.global[:document].getElementById('button').addEventListener('click') do
             JS.global[:rubyVM].evalAsync('hoge(1)')
         end
        </script>
    </body>
</html>
```

It will output:

```
[:hoge, 1, :start]
[:fuga, 1, :start]
[:fuga, 1, :end]
[:hoge, 1, :end]
```

Then if I change it to the following:

```ruby
         JS.global[:document].getElementById('button').addEventListener('click') do
             JS.global[:rubyVM].evalAsync('hoge(1)')
             JS.global[:rubyVM].evalAsync('hoge(2)')
         end
```

the output is like this, not printing `[:fuga, 2, :end]` and `[:hoge, 2, :end]`:

```
[:hoge, 1, :start]
[:hoge, 2, :start]
[:fuga, 1, :start]
[:fuga, 2, :start]
[:fuga, 1, :end]
[:hoge, 1, :end]
```

It worked fine when I removed the `@is_spinning` condition.
