### PR TITLE
Add JS::True and JS::False

### DIFF
--- a/ext/js/lib/js.rb
+++ b/ext/js/lib/js.rb
@@ -41,6 +41,30 @@ module JS
   Undefined = JS.eval("return undefined")
   Null = JS.eval("return null")
 
+  # A boolean value in JavaScript is always a JS::Object instance from Ruby's point of view.
+  # If we use the boolean value returned by a JavaScript function as the condition for an if expression in Ruby,
+  # the if expression will always be true.
+  #
+  # == Bad Example
+  #
+  #   searchParams = JS.global[:URLSearchParams].new(JS.global[:location][:search])
+  #   if searchParams.has('phrase')
+  #     # Always pass through here.
+  #     ...
+  #   else
+  #     ...
+  #   end
+  #
+  # Therefore, the JS::True constant is used to determine if the JavaScript function return value is true or false.
+  #
+  # == Good Example
+  #
+  #   if searchParams.has('phrase') == JS::True
+  #     ...
+  #   end
+  True = JS.eval("return true;")
+  False = JS.eval("return false;")
+
   class PromiseScheduler
     def initialize(loop)
       @loop = loop

--- a/packages/npm-packages/ruby-wasm-wasi/test/unit/test_js.rb
+++ b/packages/npm-packages/ruby-wasm-wasi/test/unit/test_js.rb
@@ -27,4 +27,11 @@ class JS::TestJS < Test::Unit::TestCase
   def test_try_convert
     assert_nil JS.try_convert(Object.new)
   end
+
+  def test_constasts
+    assert_equal 'null', JS::Null.to_s
+    assert_equal 'undefined', JS::Undefined.to_s
+    assert_equal 'true', JS::True.to_s
+    assert_equal 'false', JS::False.to_s
+  end
 end


### PR DESCRIPTION
This is a pull request where I switched from implementing the to_b method to implementing JS::True, as pointed out in #247.

The following use cases are assumed:
```ruby
if searchParams.has('phrase') == JS::True
  ...
end
```

It is used to correctly determine the boolean value returned from a JavaScript function in a Ruby if expression.
