### PR TITLE
Use WebAssembly.compileStreaming

### DIFF
--- a/packages/npm-packages/ruby-wasm-wasi/src/browser.script.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/browser.script.ts
@@ -1,11 +1,10 @@
 import { DefaultRubyVM } from "./browser";
 
 export const main = async (pkg: { name: string; version: string }) => {
-  const response = await fetch(
+  const response = fetch(
     `https://cdn.jsdelivr.net/npm/${pkg.name}@${pkg.version}/dist/ruby+stdlib.wasm`,
   );
-  const buffer = await response.arrayBuffer();
-  const module = await WebAssembly.compile(buffer);
+  const module = await WebAssembly.compileStreaming(response);
   const { vm } = await DefaultRubyVM(module);
 
   vm.printVersion();


### PR DESCRIPTION
With WebAssembly.compileStreaming, compilation completes 40 ms faster than WebAssembly.compile.

## Measurement Method

I subtracted the time it takes to download `ruby+stdlib.wasm` from the time it takes to compile `ruby+stdlib.wasm` and measured that as the difference between WebAssembly.compileStreaming and WebAssembly.compile.

### Compile time

We added the following script to [packages/npm-packages/ruby-wasm-wasi/src/browser.script.ts](https://github.com/ruby/ruby.wasm/blob/main/packages/npm-packages/ruby-wasm-wasi/src/browser.script.ts) and measured the time required to compile `ruby+stdlib.wasm`.

```ts
  const t0 = performance.now();

  const response = fetch(
    `https://cdn.jsdelivr.net/npm/${pkg.name}@${pkg.version}/dist/ruby+stdlib.wasm`,
  );

  // Switch comments for each measurement target.
  const module = await WebAssembly.compileStreaming(response);
  // const buffer = await response.then((res) => res.arrayBuffer());
  // const module = await WebAssembly.compile(buffer);

  const t1 = performance.now();
  console.log(`Compiling ruby+stdlib.wasm to took ${t1 - t0} milliseconds.`);
```

### Download time

The time taken to download `ruby+stdlib.wasm` was obtained from the network tab of Google Chrome.
For example:

![image](https://github.com/ruby/ruby.wasm/assets/1079508/6a8970b4-348d-4400-b2b5-2ef7dbfae51e)

Cache has been disabled.

## Measurement Results

### WebAssembly.complieStreaming

Average 21 ms

| No. | Compile time(ms) | Download time(ms) | diff(ms) |
|-----|----------------|------------------|-----|
|1     | 463                | 443                   |20    |
|2     | 387                | 364                   |22    |
|3     | 479                | 458                   |21    |

### WebAssembly.complie

Average 62.7 ms

| No. | Compile time(ms) | Download time(ms) | diff(ms) |
|-----|----------------|------------------|-----|
|1     | 485                | 425                   |60    |
|2     | 447                | 383                   |64    |
|3     | 512                | 448                   |64    |
