### PR TITLE
Separate the runRubyScriptsInHtml function as a module.

### DIFF
--- a/packages/npm-packages/ruby-wasm-wasi/src/browser.script.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/browser.script.ts
@@ -1,4 +1,5 @@
 import { DefaultRubyVM } from "./browser";
+import runRubyScriptsInHtml from "./runRubyScriptsInHtml";
 
 export const main = async (pkg: { name: string; version: string }) => {
   const response = await fetch(
@@ -22,60 +23,4 @@ export const main = async (pkg: { name: string; version: string }) => {
   } else {
     runRubyScriptsInHtml(vm);
   }
-};
-
-const runRubyScriptsInHtml = async (vm) => {
-  const tags = document.querySelectorAll('script[type="text/ruby"]');
-
-  // Get Ruby scripts in parallel.
-  const promisingRubyScripts = Array.from(tags).map((tag) =>
-    loadScriptAsync(tag),
-  );
-
-  // Run Ruby scripts sequentially.
-  for await (const script of promisingRubyScripts) {
-    if (script) {
-      const { scriptContent, evalStyle } = script;
-      switch (evalStyle) {
-        case "async":
-          vm.evalAsync(scriptContent);
-          break;
-        case "sync":
-          vm.eval(scriptContent);
-          break;
-      }
-    }
-  }
-};
-
-const deriveEvalStyle = (tag: Element): "async" | "sync" => {
-  const rawEvalStyle = tag.getAttribute("data-eval") || "sync";
-  if (rawEvalStyle !== "async" && rawEvalStyle !== "sync") {
-    console.warn(
-      `data-eval attribute of script tag must be "async" or "sync". ${rawEvalStyle} is ignored and "sync" is used instead.`,
-    );
-    return "sync";
-  }
-  return rawEvalStyle;
-};
-
-const loadScriptAsync = async (
-  tag: Element,
-): Promise<{ scriptContent: string; evalStyle: "async" | "sync" } | null> => {
-  const evalStyle = deriveEvalStyle(tag);
-  // Inline comments can be written with the src attribute of the script tag.
-  // The presence of the src attribute is checked before the presence of the inline.
-  // see: https://html.spec.whatwg.org/multipage/scripting.html#inline-documentation-for-external-scripts
-  if (tag.hasAttribute("src")) {
-    const url = tag.getAttribute("src");
-    const response = await fetch(url);
-
-    if (response.ok) {
-      return { scriptContent: await response.text(), evalStyle };
-    }
-
-    return Promise.resolve(null);
-  }
-
-  return Promise.resolve({ scriptContent: tag.innerHTML, evalStyle });
 };

--- a/packages/npm-packages/ruby-wasm-wasi/src/runRubyScriptsInHtml/deriveEvalStyle.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/runRubyScriptsInHtml/deriveEvalStyle.ts
@@ -1,0 +1,10 @@
+export default function deriveEvalStyle(tag: Element): "async" | "sync" {
+  const rawEvalStyle = tag.getAttribute("data-eval") || "sync";
+  if (rawEvalStyle !== "async" && rawEvalStyle !== "sync") {
+    console.warn(
+      `data-eval attribute of script tag must be "async" or "sync". ${rawEvalStyle} is ignored and "sync" is used instead.`,
+    );
+    return "sync";
+  }
+  return rawEvalStyle;
+}

--- a/packages/npm-packages/ruby-wasm-wasi/src/runRubyScriptsInHtml/index.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/runRubyScriptsInHtml/index.ts
@@ -1,0 +1,25 @@
+import loadScriptAsync from "./loadScriptAsync";
+
+export default async function runRubyScriptsInHtml(vm) {
+  const tags = document.querySelectorAll('script[type="text/ruby"]');
+
+  // Get Ruby scripts in parallel.
+  const promisingRubyScripts = Array.from(tags).map((tag) =>
+    loadScriptAsync(tag),
+  );
+
+  // Run Ruby scripts sequentially.
+  for await (const script of promisingRubyScripts) {
+    if (script) {
+      const { scriptContent, evalStyle } = script;
+      switch (evalStyle) {
+        case "async":
+          vm.evalAsync(scriptContent);
+          break;
+        case "sync":
+          vm.eval(scriptContent);
+          break;
+      }
+    }
+  }
+}

--- a/packages/npm-packages/ruby-wasm-wasi/src/runRubyScriptsInHtml/loadScriptAsync.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/runRubyScriptsInHtml/loadScriptAsync.ts
@@ -1,0 +1,22 @@
+import deriveEvalStyle from "./deriveEvalStyle";
+
+export default async function loadScriptAsync(
+  tag: Element,
+): Promise<{ scriptContent: string; evalStyle: "async" | "sync" } | null> {
+  const evalStyle = deriveEvalStyle(tag);
+  // Inline comments can be written with the src attribute of the script tag.
+  // The presence of the src attribute is checked before the presence of the inline.
+  // see: https://html.spec.whatwg.org/multipage/scripting.html#inline-documentation-for-external-scripts
+  if (tag.hasAttribute("src")) {
+    const url = tag.getAttribute("src");
+    const response = await fetch(url);
+
+    if (response.ok) {
+      return { scriptContent: await response.text(), evalStyle };
+    }
+
+    return Promise.resolve(null);
+  }
+
+  return Promise.resolve({ scriptContent: tag.innerHTML, evalStyle });
+}


### PR DESCRIPTION
I think the current browser.script.ts is too complicated. 

In https://github.com/ruby/ruby.wasm/blob/a64de622c5d2a7cbd2147ef789d38a6e6f5cdb18/packages/npm-packages/ruby-wasm-wasi/src/browser.script.ts , there were 28 lines.
Now there are 81 lines.

I made runRubyScriptsInHtml a module and moved the definition to a separate file.
Now I have 26 lines of browser.script.ts.

I used default export for module definitions, if you prefer named export, please let me know.