### PR TITLE
Add `JS::Object#to_a`

### DIFF
--- a/ext/js/lib/js.rb
+++ b/ext/js/lib/js.rb
@@ -138,6 +138,15 @@ class JS::Object
     JS.global[:Reflect].construct(self, args.to_js)
   end
 
+  # Converts +self+ to an Array:
+  #
+  #   JS.eval("return [1, 2, 3]").to_a.map(&:to_i)    # => [1, 2, 3]
+  #   JS.global[:document].querySelectorAll("p").to_a # => [[object HTMLParagraphElement], ...
+  def to_a
+    as_array = JS.global[:Array].from(self)
+    Array.new(as_array[:length].to_i) { as_array[_1] }
+  end
+
   # Provide a shorthand form for JS::Object#call
   #
   # This method basically calls the JavaScript method with the same

--- a/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
+++ b/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
@@ -245,6 +245,17 @@ class JS::TestObject < Test::Unit::TestCase
     assert_equal "hello", JS.global[:CustomClass].new(js_object)[:option1].to_s
   end
 
+  def test_to_a
+    assert_equal [1, 2, 3], JS.eval("return [1, 2, 3];").to_a.map(&:to_i)
+    assert_equal %w[f o o], JS.eval("return 'foo';").to_a.map(&:to_s)
+
+    set = JS.eval("return new Set(['foo', 'bar', 'baz', 'foo']);").to_a
+    assert_equal %w[foo bar baz], set.map(&:to_s)
+
+    map = JS.eval("return new Map([[1, 2], [2, 4], [4, 8]]);").to_a
+    assert_equal ({ 1 => 2, 2 => 4, 4 => 8 }), map.to_h { _1.to_a.map(&:to_i) }
+  end
+
   def test_method_missing
     assert_equal "42", JS.eval("return 42;").toString.to_s
     assert_equal "o", JS.eval("return 'hello';").charAt(4).to_s


### PR DESCRIPTION
This is a suggestion PR for a `JS::Object#to_a` method.

The motivation is to be able to more naturally enumerate collections from JavaScript, without having to separately access the length property and index it:
```ruby
# from
collection = JS.global[:document].querySelectorAll("p")
collection[:length].to_i.times do |i|
  element = collection[i]
  # ...
end

# to
JS.global[:document].querySelectorAll("p").to_a.each do |element|
  # ...
end
```

Unit tests cover some of the examples on [MDN's Array.from() page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from).