### PR TITLE
Update zlib version to resolve build errors.

### DIFF
--- a/lib/ruby_wasm/build_system/product/zlib.rb
+++ b/lib/ruby_wasm/build_system/product/zlib.rb
@@ -4,7 +4,7 @@ module RubyWasm
   class ZlibProduct < AutoconfProduct
     attr_reader :target
 
-    ZLIB_VERSION = "1.2.13"
+    ZLIB_VERSION = "1.3"
 
     def initialize(build_dir, target, toolchain)
       @build_dir = build_dir

--- a/lib/ruby_wasm/build_system/product/zlib.rb
+++ b/lib/ruby_wasm/build_system/product/zlib.rb
@@ -35,7 +35,8 @@ module RubyWasm
       FileUtils.rm_rf product_build_dir
 
       system "curl -L https://zlib.net/zlib-#{ZLIB_VERSION}.tar.gz | tar xz",
-             chdir: File.dirname(product_build_dir)
+             chdir: File.dirname(product_build_dir),
+             exception: true
 
       system "#{tools_args.join(" ")} ./configure --static",
              chdir: product_build_dir


### PR DESCRIPTION
## Problem

ruby.wasm has been failing to build for the past week.
For example, the following GitHub Actions job:
https://github.com/ruby/ruby.wasm/actions/runs/5965503425/job/16183103917

Errors are as follows:
```
*** Following extensions are not compiled:
zlib:
	Could not be configured. It will not be installed.
	Check ext/zlib/mkmf.log for more details.
*** Fix the problems, then remove these directories and try again if you want.
```

Also, `build/wasm32-unknown-wasi/head-wasm32-unknown-wasi-full-js-debug/ext/zlib/mkmf.log` shows that `ruby/zlib` compilation fails because `zlib.h` is missing. The `zlib` referred to in this case is not the `zlib` installed on the system, but the `zlib` obtained by `lib/ruby_wasm/build_system/product/zlib.rb`.

## Cause

`zlib.rb` tries to download `zlib 1.2.13` from zlib.net. zlib.net distributes the latest zlib. 1.2.13 worked fine when it was up to date. `zlib 1.3` was released and `zlib 1.2.13` is no longer distributed. 

## Solution

Update zlib version to 1.3 to be downloaded in `zlib.rb`.

Of course this is not a radical solution. Once a new version of zlib is released, the same problem should occur again. Of course this is not a radical solution. Once a new version of zlib is released, the same problem should occur again. So, to make it easier to understand the cause of the build error, I have added an option to raise an exception when the zlib download fails.

Perhaps it would be better to check out the version from https://github.com/madler/zlib.