### PR TITLE
Improve `Array#to_js` speed

### DIFF
--- a/ext/js/lib/js/array.rb
+++ b/ext/js/lib/js/array.rb
@@ -2,10 +2,8 @@ class Array
   # Convert Ruby array to JavaScript array
   def to_js
     new_array = JS.eval("return []")
-    self.each do |element|
-      # NOTE: This method call implicitly convert element to JS object by to_js
-      new_array.push element
-    end
+    # NOTE: This method call implicitly convert element to JS object by to_js
+    new_array.push *self
     new_array
   end
 end


### PR DESCRIPTION
Hi I am struggling with a large overhead when porting large sized arrays from Ruby to JS.
I found that this is caused by the implicit conversion `Array#to_js` and so I made this performance improvement.

measurement code below:

```rb
require "js"

JS.global[:console].time "old"
new_array = JS.eval("return []")
Array.new(10000).each do |element|
  new_array.push element
end
JS.global[:console].timeEnd "old" # 174.81494140625 ms

JS.global[:console].time "new"
new_array = JS.eval("return []")
Array.new(10000).each_slice(100) do |elements|
  new_array.push *elements
end
JS.global[:console].timeEnd "new" # 14.78466796875 ms
```