### PR TITLE
Fix build error on mac

### DIFF
--- a/lib/ruby_wasm/build_system/product/openssl.rb
+++ b/lib/ruby_wasm/build_system/product/openssl.rb
@@ -31,6 +31,7 @@ module RubyWasm
 
     def configure_args
       args = %w[
+        gcc
         -static
         -no-asm
         -no-threads
@@ -64,7 +65,7 @@ module RubyWasm
       system "./Configure #{configure_args.join(" ")}", chdir: product_build_dir
       # Use "install_sw" instead of "install" because it tries to install docs and it's very slow.
       # OpenSSL build system doesn't have well support for parallel build, so force -j1.
-      system "make -j1 install_sw DESTDIR=#{destdir} CNF_CFLAGS='' CNF_LDFLAGS=''", chdir: product_build_dir
+      system "make -j1 install_sw DESTDIR=#{destdir}", chdir: product_build_dir
     end
   end
 end

--- a/lib/ruby_wasm/build_system/product/openssl.rb
+++ b/lib/ruby_wasm/build_system/product/openssl.rb
@@ -64,7 +64,7 @@ module RubyWasm
       system "./Configure #{configure_args.join(" ")}", chdir: product_build_dir
       # Use "install_sw" instead of "install" because it tries to install docs and it's very slow.
       # OpenSSL build system doesn't have well support for parallel build, so force -j1.
-      system "make -j1 install_sw DESTDIR=#{destdir}", chdir: product_build_dir
+      system "make -j1 install_sw DESTDIR=#{destdir} CNF_CFLAGS='' CNF_LDFLAGS=''", chdir: product_build_dir
     end
   end
 end

--- a/lib/ruby_wasm/build_system/product/zlib.rb
+++ b/lib/ruby_wasm/build_system/product/zlib.rb
@@ -28,6 +28,14 @@ module RubyWasm
       product_build_dir
     end
 
+    def configure_args
+      args = %w[
+        CHOST=linux
+      ]
+
+      args + tools_args
+    end
+
     def build
       return if Dir.exist?(install_root)
 
@@ -38,9 +46,9 @@ module RubyWasm
              chdir: File.dirname(product_build_dir),
              exception: true
 
-      system "#{tools_args.join(" ")} ./configure --static",
+      system "#{configure_args.join(" ")} ./configure --static",
              chdir: product_build_dir
-      system "make install DESTDIR=#{destdir} AR='#{@toolchain.ar}' ARFLAGS='rcD'",
+      system "make install DESTDIR=#{destdir}",
              chdir: product_build_dir
     end
   end

--- a/lib/ruby_wasm/build_system/product/zlib.rb
+++ b/lib/ruby_wasm/build_system/product/zlib.rb
@@ -40,7 +40,8 @@ module RubyWasm
 
       system "#{tools_args.join(" ")} ./configure --static",
              chdir: product_build_dir
-      system "make install DESTDIR=#{destdir}", chdir: product_build_dir
+      system "make install DESTDIR=#{destdir} AR='#{@toolchain.ar}' ARFLAGS='rcD'",
+             chdir: product_build_dir
     end
   end
 end


### PR DESCRIPTION
I am a Mac user, but I was unable to build it due to issues with the build options for zlib and openssl. 
```shell
$ uname -a
Darwin ahogappAir.local 23.0.0 Darwin Kernel Version 23.0.0: Fri Sep 15 14:41:34 PDT 2023; root:xnu-10002.1.13~1/RELEASE_ARM64_T8103 arm64
```

## zlib
I received an error log while trying to build the zlib product:
```shell
Building static library libz.a version 1.3 with /Users/ahogappa/project/wasi-sdk/build/install/opt/wasi-sdk/bin/clang.
Checking for size_t... Yes.
Checking for off64_t... Yes.
Checking for fseeko... Yes.
Checking for strerror... Yes.
Checking for unistd.h... Yes.
Checking for stdarg.h... Yes.
Checking whether to use vs[n]printf() or s[n]printf()... using vs[n]printf().
Checking for vsnprintf() in stdio.h... Yes.
Checking for return value of vsnprintf()... Yes.
Checking for attribute(visibility) support... Yes.
/Users/ahogappa/project/wasi-sdk/build/install/opt/wasi-sdk/bin/clang -O3 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN  -c -o adler32.o adler32.c
/Users/ahogappa/project/wasi-sdk/build/install/opt/wasi-sdk/bin/clang -O3 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN  -c -o crc32.o crc32.c
/Users/ahogappa/project/wasi-sdk/build/install/opt/wasi-sdk/bin/clang -O3 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN  -c -o deflate.o deflate.c
/Users/ahogappa/project/wasi-sdk/build/install/opt/wasi-sdk/bin/clang -O3 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN  -c -o infback.o infback.c
/Users/ahogappa/project/wasi-sdk/build/install/opt/wasi-sdk/bin/clang -O3 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN  -c -o inffast.o inffast.c
/Users/ahogappa/project/wasi-sdk/build/install/opt/wasi-sdk/bin/clang -O3 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN  -c -o inflate.o inflate.c
/Users/ahogappa/project/wasi-sdk/build/install/opt/wasi-sdk/bin/clang -O3 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN  -c -o inftrees.o inftrees.c
/Users/ahogappa/project/wasi-sdk/build/install/opt/wasi-sdk/bin/clang -O3 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN  -c -o trees.o trees.c
/Users/ahogappa/project/wasi-sdk/build/install/opt/wasi-sdk/bin/clang -O3 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN  -c -o zutil.o zutil.c
/Users/ahogappa/project/wasi-sdk/build/install/opt/wasi-sdk/bin/clang -O3 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN  -c -o compress.o compress.c
/Users/ahogappa/project/wasi-sdk/build/install/opt/wasi-sdk/bin/clang -O3 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN  -c -o uncompr.o uncompr.c
/Users/ahogappa/project/wasi-sdk/build/install/opt/wasi-sdk/bin/clang -O3 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN  -c -o gzclose.o gzclose.c
/Users/ahogappa/project/wasi-sdk/build/install/opt/wasi-sdk/bin/clang -O3 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN  -c -o gzlib.o gzlib.c
/Users/ahogappa/project/wasi-sdk/build/install/opt/wasi-sdk/bin/clang -O3 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN  -c -o gzread.o gzread.c
/Users/ahogappa/project/wasi-sdk/build/install/opt/wasi-sdk/bin/clang -O3 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN  -c -o gzwrite.o gzwrite.c
libtool -o libz.a adler32.o crc32.o deflate.o infback.o inffast.o inflate.o inftrees.o trees.o zutil.o compress.o uncompr.o gzclose.o gzlib.o gzread.o gzwrite.o
error: /Library/Developer/CommandLineTools/usr/bin/libtool: file: adler32.o is not an object file (not allowed in a library)
error: /Library/Developer/CommandLineTools/usr/bin/libtool: file: crc32.o is not an object file (not allowed in a library)
error: /Library/Developer/CommandLineTools/usr/bin/libtool: file: deflate.o is not an object file (not allowed in a library)
error: /Library/Developer/CommandLineTools/usr/bin/libtool: file: infback.o is not an object file (not allowed in a library)
error: /Library/Developer/CommandLineTools/usr/bin/libtool: file: inffast.o is not an object file (not allowed in a library)
error: /Library/Developer/CommandLineTools/usr/bin/libtool: file: inflate.o is not an object file (not allowed in a library)
error: /Library/Developer/CommandLineTools/usr/bin/libtool: file: inftrees.o is not an object file (not allowed in a library)
error: /Library/Developer/CommandLineTools/usr/bin/libtool: file: trees.o is not an object file (not allowed in a library)
error: /Library/Developer/CommandLineTools/usr/bin/libtool: file: zutil.o is not an object file (not allowed in a library)
error: /Library/Developer/CommandLineTools/usr/bin/libtool: file: compress.o is not an object file (not allowed in a library)
error: /Library/Developer/CommandLineTools/usr/bin/libtool: file: uncompr.o is not an object file (not allowed in a library)
error: /Library/Developer/CommandLineTools/usr/bin/libtool: file: gzclose.o is not an object file (not allowed in a library)
error: /Library/Developer/CommandLineTools/usr/bin/libtool: file: gzlib.o is not an object file (not allowed in a library)
error: /Library/Developer/CommandLineTools/usr/bin/libtool: file: gzread.o is not an object file (not allowed in a library)
error: /Library/Developer/CommandLineTools/usr/bin/libtool: file: gzwrite.o is not an object file (not allowed in a library)
make: *** [libz.a] Error 1
```
Trying to link something compiled using wasm-clang with an incompatible libtool.

in zlib configure file:
```
case "$uname" in
…
Darwin* | darwin* | *-darwin*)
…
if "${CROSS_PREFIX}libtool" -V 2>&1 | grep Apple > /dev/null; then
   AR="${CROSS_PREFIX}libtool"
elif libtool -V 2>&1 | grep Apple > /dev/null; then
   AR="libtool"
else
   AR="/usr/bin/libtool"
fi
```
A Mac user using Xcode's `libtool' cannot be linked.

## openssl
Trying to build the openssl product:
```shell
${LDCMD:-/Users/ahogappa/project/wasi-sdk/build/install/opt/wasi-sdk/bin/clang} -arch arm64 -O3 -Wall -L. -Wl,-search_paths_first -L/opt/homebrew/lib -static -Wl,--allow-undefined \
		-o apps/openssl \
		apps/lib/openssl-bin-cmp_mock_srv.o \
		apps/openssl-bin-asn1parse.o apps/openssl-bin-ca.o \
		apps/openssl-bin-ciphers.o apps/openssl-bin-cmp.o \
		apps/openssl-bin-cms.o apps/openssl-bin-crl.o \
		apps/openssl-bin-crl2pkcs7.o apps/openssl-bin-dgst.o \
		apps/openssl-bin-dhparam.o apps/openssl-bin-dsa.o \
		apps/openssl-bin-dsaparam.o apps/openssl-bin-ec.o \
		apps/openssl-bin-ecparam.o apps/openssl-bin-enc.o \
		apps/openssl-bin-engine.o apps/openssl-bin-errstr.o \
		apps/openssl-bin-fipsinstall.o apps/openssl-bin-gendsa.o \
		apps/openssl-bin-genpkey.o apps/openssl-bin-genrsa.o \
		apps/openssl-bin-info.o apps/openssl-bin-kdf.o \
		apps/openssl-bin-list.o apps/openssl-bin-mac.o \
		apps/openssl-bin-nseq.o apps/openssl-bin-ocsp.o \
		apps/openssl-bin-openssl.o apps/openssl-bin-passwd.o \
		apps/openssl-bin-pkcs12.o apps/openssl-bin-pkcs7.o \
		apps/openssl-bin-pkcs8.o apps/openssl-bin-pkey.o \
		apps/openssl-bin-pkeyparam.o apps/openssl-bin-pkeyutl.o \
		apps/openssl-bin-prime.o apps/openssl-bin-progs.o \
		apps/openssl-bin-rand.o apps/openssl-bin-rehash.o \
		apps/openssl-bin-req.o apps/openssl-bin-rsa.o \
		apps/openssl-bin-rsautl.o apps/openssl-bin-s_client.o \
		apps/openssl-bin-s_server.o apps/openssl-bin-s_time.o \
		apps/openssl-bin-sess_id.o apps/openssl-bin-smime.o \
		apps/openssl-bin-speed.o apps/openssl-bin-spkac.o \
		apps/openssl-bin-srp.o apps/openssl-bin-storeutl.o \
		apps/openssl-bin-ts.o apps/openssl-bin-verify.o \
		apps/openssl-bin-version.o apps/openssl-bin-x509.o \
		apps/libapps.a -lssl -lcrypto
clang-14: warning: argument unused during compilation: '-arch arm64' [-Wunused-command-line-argument]
wasm-ld: error: unknown argument: -search_paths_first
clang-14: error: linker command failed with exit code 1 (use -v to see invocation)
```

in openssl Makefile:
```shell
CNF_CFLAGS=-arch arm64
CNF_LDFLAGS=-Wl,-search_paths_first
```
I removed some options that weren't needed.