### PR TITLE
Modify the URL pattern to be replaced in the mock as the npm package is moved.

### DIFF
--- a/packages/npm-packages/ruby-wasm-wasi/test-e2e/support.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/test-e2e/support.ts
@@ -18,7 +18,7 @@ export const setupDebugLog = (context: BrowserContext) => {
 };
 
 export const setupProxy = (context: BrowserContext) => {
-  const cdnPattern = /cdn.jsdelivr.net\/npm\/ruby-.+-wasm-wasi@.+\/dist\/(.+)/;
+  const cdnPattern = /cdn.jsdelivr.net\/npm\/@ruby\/.+-wasm-wasi@.+\/dist\/(.+)/;
   context.route(cdnPattern, (route) => {
     const request = route.request();
     console.log(">> [MOCK]", request.method(), request.url());


### PR DESCRIPTION
The npm package has been moved in #325.
At the same time, the packages referenced in the test code have been fixed.

The pattern of URLs to mock was not fixed.
