### PR TITLE
Make `RbExceptionFormatter#format` error tolerant

### DIFF
--- a/packages/npm-packages/ruby-wasm-wasi/test/vm.test.js
+++ b/packages/npm-packages/ruby-wasm-wasi/test/vm.test.js
@@ -113,6 +113,25 @@ eval:3:in \`foo'
 eval:11:in \`<main>'`);
   });
 
+  test("exception while formatting exception backtrace", async () => {
+    const vm = await initRubyVM();
+    const throwError = () => {
+      vm.eval(`
+      class BrokenException < Exception
+        def to_s
+          raise "something went wrong in BrokenException#to_s"
+        end
+        def backtrace
+          raise "something went wrong in BrokenException#backtrace"
+        end
+      end
+      raise BrokenException.new
+      `);
+    }
+    expect(throwError)
+      .toThrowError(`BrokenException: unknown`);
+  });
+
   test("eval encoding", async () => {
     const vm = await initRubyVM();
     expect(vm.eval(`Encoding.default_external.name`).toString()).toBe("UTF-8");


### PR DESCRIPTION
Ruby exceptions can be raised during formatting exceptions, so the formatting logic can be infinitely recursion and it makes the backtrace difficult to read. 

Here is an example crash log for such case.

```
...
Crashed while printing bug report
Crashed while printing bug report
Crashed while printing bug report
...
at RbAbiGuest.apply [as rbVmBugreport] (dist/cjs/index.js:63:44)
at rbVmBugreport (dist/cjs/index.js:550:18)
at wrapRbOperation (dist/cjs/index.js:563:12)
at RbValue.callRbMethod [as call] (dist/cjs/index.js:419:28)
at RbExceptionFormatter.call [as format] (dist/cjs/index.js:489:33)
at format (dist/cjs/index.js:535:64)
at checkStatusTag (dist/cjs/index.js:565:9)
at body (dist/cjs/index.js:542:16)
at wrapRbOperation (dist/cjs/index.js:563:12)
at RbValue.callRbMethod [as call] (dist/cjs/index.js:419:28)
at RbExceptionFormatter.call [as format] (dist/cjs/index.js:489:33)
at format (dist/cjs/index.js:535:64)
at checkStatusTag (dist/cjs/index.js:565:9)
at body (dist/cjs/index.js:542:16)
at wrapRbOperation (dist/cjs/index.js:563:12)
at RbValue.callRbMethod [as call] (dist/cjs/index.js:419:28)
at RbExceptionFormatter.call [as format] (dist/cjs/index.js:489:33)
at format (dist/cjs/index.js:535:64)
at checkStatusTag (dist/cjs/index.js:565:9)
at body (dist/cjs/index.js:542:16)
...
```