### PR TITLE
Use `@bjorn3/browser_wasi_shim` for WASI on browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -486,9 +486,9 @@
             "license": "MIT"
         },
         "node_modules/@bjorn3/browser_wasi_shim": {
-            "version": "0.2.16",
-            "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.16.tgz",
-            "integrity": "sha512-LyW996vWlBRmfUvJz9m89+pSEpGK9B2UdYRTGiOEYkqyhKP8fafC2c7+2idEnjPQXWfA8VkFYRCUDGBVAl9d3g==",
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.17.tgz",
+            "integrity": "sha512-B2qcaGROo4e2s4nXb3VPATrczVrntM4BUXtAU1gEzUOfqKTcVuePq4NfhH5hmLBSvZ45YcT4gflDRUFYqLhkxA==",
             "dev": true
         },
         "node_modules/@istanbuljs/load-nyc-config": {
@@ -5115,7 +5115,7 @@
                 "tslib": "^2.6.1"
             },
             "devDependencies": {
-                "@bjorn3/browser_wasi_shim": "^0.2.16",
+                "@bjorn3/browser_wasi_shim": "^0.2.17",
                 "@rollup/plugin-node-resolve": "^15.1.0",
                 "@rollup/plugin-typescript": "^11.1.2",
                 "@types/jest": "^29.5.3",
@@ -5480,9 +5480,9 @@
             "dev": true
         },
         "@bjorn3/browser_wasi_shim": {
-            "version": "0.2.16",
-            "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.16.tgz",
-            "integrity": "sha512-LyW996vWlBRmfUvJz9m89+pSEpGK9B2UdYRTGiOEYkqyhKP8fafC2c7+2idEnjPQXWfA8VkFYRCUDGBVAl9d3g==",
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.17.tgz",
+            "integrity": "sha512-B2qcaGROo4e2s4nXb3VPATrczVrntM4BUXtAU1gEzUOfqKTcVuePq4NfhH5hmLBSvZ45YcT4gflDRUFYqLhkxA==",
             "dev": true
         },
         "@istanbuljs/load-nyc-config": {
@@ -6122,7 +6122,7 @@
         "@ruby/wasm-wasi": {
             "version": "file:packages/npm-packages/ruby-wasm-wasi",
             "requires": {
-                "@bjorn3/browser_wasi_shim": "^0.2.16",
+                "@bjorn3/browser_wasi_shim": "^0.2.17",
                 "@rollup/plugin-node-resolve": "^15.1.0",
                 "@rollup/plugin-typescript": "^11.1.2",
                 "@types/jest": "^29.5.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -485,6 +485,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@bjorn3/browser_wasi_shim": {
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.16.tgz",
+            "integrity": "sha512-LyW996vWlBRmfUvJz9m89+pSEpGK9B2UdYRTGiOEYkqyhKP8fafC2c7+2idEnjPQXWfA8VkFYRCUDGBVAl9d3g==",
+            "dev": true
+        },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "dev": true,
@@ -1223,38 +1229,6 @@
                 }
             }
         },
-        "node_modules/@rollup/plugin-inject": {
-            "version": "5.0.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@rollup/pluginutils": "^5.0.1",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.3"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-            },
-            "peerDependenciesMeta": {
-                "rollup": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@rollup/plugin-inject/node_modules/magic-string": {
-            "version": "0.30.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.4.15"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/@rollup/plugin-json": {
             "version": "6.0.1",
             "dev": true,
@@ -1519,11 +1493,6 @@
         },
         "node_modules/@types/yargs-parser": {
             "version": "21.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@wasmer/wasi": {
-            "version": "1.2.2",
             "dev": true,
             "license": "MIT"
         },
@@ -4537,6 +4506,7 @@
             "version": "3.22.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "peer": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -4547,18 +4517,6 @@
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
-            }
-        },
-        "node_modules/rollup-plugin-polyfill-node": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/rollup-plugin-polyfill-node/-/rollup-plugin-polyfill-node-0.13.0.tgz",
-            "integrity": "sha512-FYEvpCaD5jGtyBuBFcQImEGmTxDTPbiHjJdrYIp+mFIwgXiXabxvKUK7ZT9P31ozu2Tqm9llYQMRWsfvTMTAOw==",
-            "dev": true,
-            "dependencies": {
-                "@rollup/plugin-inject": "^5.0.4"
-            },
-            "peerDependencies": {
-                "rollup": "^1.20.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
             }
         },
         "node_modules/semver": {
@@ -5035,10 +4993,8 @@
                 "@ruby/wasm-wasi": "^2.0.0"
             },
             "devDependencies": {
-                "@rollup/plugin-inject": "^5.0.5",
                 "@rollup/plugin-json": "^6.0.1",
-                "rollup": "^4.6.1",
-                "rollup-plugin-polyfill-node": "^0.13.0"
+                "rollup": "^4.6.1"
             }
         },
         "packages/npm-packages/ruby-3.2-wasm-wasi/node_modules/rollup": {
@@ -5082,10 +5038,8 @@
                 "@ruby/wasm-wasi": "^2.0.0"
             },
             "devDependencies": {
-                "@rollup/plugin-inject": "^5.0.5",
                 "@rollup/plugin-json": "^6.0.1",
-                "rollup": "^4.6.1",
-                "rollup-plugin-polyfill-node": "^0.13.0"
+                "rollup": "^4.6.1"
             }
         },
         "packages/npm-packages/ruby-head-wasm-wasi/node_modules/rollup": {
@@ -5161,16 +5115,14 @@
                 "tslib": "^2.6.1"
             },
             "devDependencies": {
-                "@rollup/plugin-inject": "^5.0.5",
+                "@bjorn3/browser_wasi_shim": "^0.2.16",
                 "@rollup/plugin-node-resolve": "^15.1.0",
                 "@rollup/plugin-typescript": "^11.1.2",
                 "@types/jest": "^29.5.3",
                 "@types/node": "20.8.10",
-                "@wasmer/wasi": "^1.2.2",
                 "jest": "^29.6.2",
                 "prettier": "^3.0.0",
                 "rollup": "^4.6.1",
-                "rollup-plugin-polyfill-node": "^0.13.0",
                 "typescript": "^5.3.2"
             }
         },
@@ -5525,6 +5477,12 @@
         },
         "@bcoe/v8-coverage": {
             "version": "0.2.3",
+            "dev": true
+        },
+        "@bjorn3/browser_wasi_shim": {
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.16.tgz",
+            "integrity": "sha512-LyW996vWlBRmfUvJz9m89+pSEpGK9B2UdYRTGiOEYkqyhKP8fafC2c7+2idEnjPQXWfA8VkFYRCUDGBVAl9d3g==",
             "dev": true
         },
         "@istanbuljs/load-nyc-config": {
@@ -6016,24 +5974,6 @@
                 "magic-string": "^0.27.0"
             }
         },
-        "@rollup/plugin-inject": {
-            "version": "5.0.5",
-            "dev": true,
-            "requires": {
-                "@rollup/pluginutils": "^5.0.1",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.3"
-            },
-            "dependencies": {
-                "magic-string": {
-                    "version": "0.30.5",
-                    "dev": true,
-                    "requires": {
-                        "@jridgewell/sourcemap-codec": "^1.4.15"
-                    }
-                }
-            }
-        },
         "@rollup/plugin-json": {
             "version": "6.0.1",
             "dev": true,
@@ -6087,11 +6027,9 @@
         "@ruby/3.2-wasm-wasi": {
             "version": "file:packages/npm-packages/ruby-3.2-wasm-wasi",
             "requires": {
-                "@rollup/plugin-inject": "^5.0.5",
                 "@rollup/plugin-json": "^6.0.1",
                 "@ruby/wasm-wasi": "^2.0.0",
-                "rollup": "^4.6.1",
-                "rollup-plugin-polyfill-node": "^0.13.0"
+                "rollup": "^4.6.1"
             },
             "dependencies": {
                 "rollup": {
@@ -6123,11 +6061,9 @@
         "@ruby/head-wasm-wasi": {
             "version": "file:packages/npm-packages/ruby-head-wasm-wasi",
             "requires": {
-                "@rollup/plugin-inject": "^5.0.5",
                 "@rollup/plugin-json": "^6.0.1",
                 "@ruby/wasm-wasi": "^2.0.0",
-                "rollup": "^4.6.1",
-                "rollup-plugin-polyfill-node": "^0.13.0"
+                "rollup": "^4.6.1"
             },
             "dependencies": {
                 "rollup": {
@@ -6186,16 +6122,14 @@
         "@ruby/wasm-wasi": {
             "version": "file:packages/npm-packages/ruby-wasm-wasi",
             "requires": {
-                "@rollup/plugin-inject": "^5.0.5",
+                "@bjorn3/browser_wasi_shim": "^0.2.16",
                 "@rollup/plugin-node-resolve": "^15.1.0",
                 "@rollup/plugin-typescript": "^11.1.2",
                 "@types/jest": "^29.5.3",
                 "@types/node": "20.8.10",
-                "@wasmer/wasi": "^1.2.2",
                 "jest": "^29.6.2",
                 "prettier": "^3.0.0",
                 "rollup": "^4.6.1",
-                "rollup-plugin-polyfill-node": "^0.13.0",
                 "tslib": "^2.6.1",
                 "typescript": "^5.3.2"
             },
@@ -6335,10 +6269,6 @@
         },
         "@types/yargs-parser": {
             "version": "21.0.0",
-            "dev": true
-        },
-        "@wasmer/wasi": {
-            "version": "1.2.2",
             "dev": true
         },
         "ansi-escapes": {
@@ -8226,18 +8156,10 @@
         "rollup": {
             "version": "3.22.0",
             "dev": true,
+            "optional": true,
             "peer": true,
             "requires": {
                 "fsevents": "~2.3.2"
-            }
-        },
-        "rollup-plugin-polyfill-node": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/rollup-plugin-polyfill-node/-/rollup-plugin-polyfill-node-0.13.0.tgz",
-            "integrity": "sha512-FYEvpCaD5jGtyBuBFcQImEGmTxDTPbiHjJdrYIp+mFIwgXiXabxvKUK7ZT9P31ozu2Tqm9llYQMRWsfvTMTAOw==",
-            "dev": true,
-            "requires": {
-                "@rollup/plugin-inject": "^5.0.4"
             }
         },
         "semver": {

--- a/packages/npm-packages/ruby-3.2-wasm-wasi/package.json
+++ b/packages/npm-packages/ruby-3.2-wasm-wasi/package.json
@@ -45,10 +45,8 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@rollup/plugin-inject": "^5.0.5",
     "@rollup/plugin-json": "^6.0.1",
-    "rollup": "^4.6.1",
-    "rollup-plugin-polyfill-node": "^0.13.0"
+    "rollup": "^4.6.1"
   },
   "dependencies": {
     "@ruby/wasm-wasi": "^2.0.0"

--- a/packages/npm-packages/ruby-head-wasm-wasi/package.json
+++ b/packages/npm-packages/ruby-head-wasm-wasi/package.json
@@ -45,10 +45,8 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@rollup/plugin-inject": "^5.0.5",
     "@rollup/plugin-json": "^6.0.1",
-    "rollup": "^4.6.1",
-    "rollup-plugin-polyfill-node": "^0.13.0"
+    "rollup": "^4.6.1"
   },
   "dependencies": {
     "@ruby/wasm-wasi": "^2.0.0"

--- a/packages/npm-packages/ruby-head-wasm-wasi/rollup.config.mjs
+++ b/packages/npm-packages/ruby-head-wasm-wasi/rollup.config.mjs
@@ -1,7 +1,5 @@
 import json from "@rollup/plugin-json";
-import inject from "@rollup/plugin-inject";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
-import nodePolyfills from "rollup-plugin-polyfill-node";
 import fs from "fs";
 import path from "path";
 
@@ -17,8 +15,6 @@ export default [
       }
     ],
     plugins: [
-      nodePolyfills(),
-      inject({ Buffer: ["buffer", "Buffer"] }),
       json(), nodeResolve()
     ],
   },

--- a/packages/npm-packages/ruby-wasm-wasi/example/index.node.js
+++ b/packages/npm-packages/ruby-wasm-wasi/example/index.node.js
@@ -1,5 +1,5 @@
 import fs from "fs/promises";
-import { DefaultRubyVM } from "@ruby/head-wasm-wasi/dist/node.cjs.js";
+import { DefaultRubyVM } from "@ruby/wasm-wasi/dist/node";
 
 // $ node --experimental-wasi-unstable-preview1 index.node.js
 

--- a/packages/npm-packages/ruby-wasm-wasi/example/package.json
+++ b/packages/npm-packages/ruby-wasm-wasi/example/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@wasmer/wasi": "^0.12.0",
     "@wasmer/wasmfs": "^0.12.0",
-    "@ruby/head-wasm-wasi": "0.2.0"
+    "@ruby/head-wasm-wasi": "../../ruby-head-wasm-wasi"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^21.0.1",

--- a/packages/npm-packages/ruby-wasm-wasi/example/package.json
+++ b/packages/npm-packages/ruby-wasm-wasi/example/package.json
@@ -5,13 +5,9 @@
     "serve": "ruby -run -ehttpd"
   },
   "dependencies": {
-    "@wasmer/wasi": "^0.12.0",
-    "@wasmer/wasmfs": "^0.12.0",
     "@ruby/head-wasm-wasi": "../../ruby-head-wasm-wasi"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^21.0.1",
-    "@rollup/plugin-node-resolve": "^13.1.1",
     "rollup": "^2.62.0"
   }
 }

--- a/packages/npm-packages/ruby-wasm-wasi/package.json
+++ b/packages/npm-packages/ruby-wasm-wasi/package.json
@@ -62,7 +62,7 @@
     "jest": "^29.6.2",
     "prettier": "^3.0.0",
     "rollup": "^4.6.1",
-    "@bjorn3/browser_wasi_shim": "^0.2.16",
+    "@bjorn3/browser_wasi_shim": "^0.2.17",
     "typescript": "^5.3.2"
   },
   "dependencies": {

--- a/packages/npm-packages/ruby-wasm-wasi/package.json
+++ b/packages/npm-packages/ruby-wasm-wasi/package.json
@@ -55,16 +55,14 @@
     "build": "npm run build:rollup && npm run build:tsc && npm run build:static && ./tools/post-build.sh ./dist"
   },
   "devDependencies": {
-    "@rollup/plugin-inject": "^5.0.5",
     "@rollup/plugin-node-resolve": "^15.1.0",
     "@rollup/plugin-typescript": "^11.1.2",
     "@types/jest": "^29.5.3",
     "@types/node": "20.8.10",
-    "@wasmer/wasi": "^1.2.2",
     "jest": "^29.6.2",
     "prettier": "^3.0.0",
     "rollup": "^4.6.1",
-    "rollup-plugin-polyfill-node": "^0.13.0",
+    "@bjorn3/browser_wasi_shim": "^0.2.16",
     "typescript": "^5.3.2"
   },
   "dependencies": {

--- a/packages/npm-packages/ruby-wasm-wasi/rollup.config.mjs
+++ b/packages/npm-packages/ruby-wasm-wasi/rollup.config.mjs
@@ -1,7 +1,5 @@
-import inject from "@rollup/plugin-inject";
 import typescript from "@rollup/plugin-typescript";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
-import nodePolyfills from "rollup-plugin-polyfill-node";
 
 const typescriptOptions = { tsconfig: "./tsconfig.json", declaration: false };
 
@@ -14,10 +12,8 @@ function config({ basename }) {
       name: "ruby-wasm-wasi",
     },
     plugins: [
-      nodePolyfills(),
-      inject({ Buffer: ["buffer", "Buffer"] }),
       typescript(typescriptOptions),
-      nodeResolve({ resolveOnly: ["@wasmer/wasi"] }),
+      nodeResolve({ resolveOnly: ["@bjorn3/browser_wasi_shim"] }),
     ],
   };
 }

--- a/packages/npm-packages/ruby-wasm-wasi/src/browser.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/browser.ts
@@ -1,6 +1,5 @@
 import { Fd, WASI } from "@bjorn3/browser_wasi_shim";
-import { RubyVM } from "./index.js";
-import { consolePrinter } from "./console.js";
+import { RubyVM, consolePrinter } from "./index.js";
 
 export const DefaultRubyVM = async (
   rubyModule: WebAssembly.Module,

--- a/packages/npm-packages/ruby-wasm-wasi/src/browser.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/browser.ts
@@ -1,4 +1,4 @@
-import { Fd, File, OpenFile, WASI } from "@bjorn3/browser_wasi_shim";
+import { Fd, WASI } from "@bjorn3/browser_wasi_shim";
 import { RubyVM } from "./index.js";
 import { consolePrinter } from "./console.js";
 
@@ -18,31 +18,7 @@ export const DefaultRubyVM = async (
     ([k, v]) => `${k}=${v}`,
   );
 
-  // WORKAROUND: `@bjorn3/browser_wasi_shim` does not set proper rights
-  // and filetypes for stdout and stderr, but wasi-libc's fcntl(2) respects
-  // rights and  CRuby checks it. So we need to override `fd_fdstat_get` here.
-  const FILETYPE_CHARACTER_DEVICE = 2;
-  class Stdout extends OpenFile {
-    fd_filestat_get() {
-      const { ret, filestat } = super.fd_filestat_get();
-      filestat.filetype = FILETYPE_CHARACTER_DEVICE;
-      return { ret, filestat };
-    }
-
-    fd_fdstat_get() {
-      const { ret, fdstat } = super.fd_fdstat_get();
-      const RIGHTS_FD_WRITE = BigInt(1);
-      fdstat.fs_filetype = FILETYPE_CHARACTER_DEVICE;
-      fdstat.fs_rights_base = RIGHTS_FD_WRITE;
-      return { ret, fdstat };
-    }
-  }
-
-  const fds: Fd[] = [
-    new OpenFile(new File([])), // stdin
-    new Stdout(new File([])), // stdout
-    new Stdout(new File([])), // stderr
-  ];
+  const fds: Fd[] = [];
   const wasi = new WASI(args, env, fds, { debug: false });
   const vm = new RubyVM();
 

--- a/packages/npm-packages/ruby-wasm-wasi/src/browser.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/browser.ts
@@ -1,4 +1,4 @@
-import { init, WASI } from "@wasmer/wasi";
+import { Fd, File, OpenFile, WASI } from "@bjorn3/browser_wasi_shim";
 import { RubyVM } from "./index.js";
 import { consolePrinter } from "./console.js";
 
@@ -13,25 +13,76 @@ export const DefaultRubyVM = async (
   wasi: WASI;
   instance: WebAssembly.Instance;
 }> => {
-  await init();
+  const args: string[] = [];
+  const env: string[] = Object.entries(options.env ?? {}).map(
+    ([k, v]) => `${k}=${v}`,
+  );
 
-  const wasi = new WASI({ env: options.env });
+  // WORKAROUND: `@bjorn3/browser_wasi_shim` does not set proper rights
+  // and filetypes for stdout and stderr, but wasi-libc's fcntl(2) respects
+  // rights and  CRuby checks it. So we need to override `fd_fdstat_get` here.
+  const FILETYPE_CHARACTER_DEVICE = 2;
+  class Stdout extends OpenFile {
+    fd_filestat_get() {
+      const { ret, filestat } = super.fd_filestat_get();
+      filestat.filetype = FILETYPE_CHARACTER_DEVICE;
+      return { ret, filestat };
+    }
+
+    fd_fdstat_get() {
+      const { ret, fdstat } = super.fd_fdstat_get();
+      const RIGHTS_FD_WRITE = BigInt(1);
+      fdstat.fs_filetype = FILETYPE_CHARACTER_DEVICE;
+      fdstat.fs_rights_base = RIGHTS_FD_WRITE;
+      return { ret, fdstat };
+    }
+  }
+
+  const fds: Fd[] = [
+    new OpenFile(new File([])), // stdin
+    new Stdout(new File([])), // stdout
+    new Stdout(new File([])), // stderr
+  ];
+  const wasi = new WASI(args, env, fds, { debug: false });
   const vm = new RubyVM();
 
-  const imports = wasi.getImports(rubyModule) as WebAssembly.Imports;
+  const imports = {
+    wasi_snapshot_preview1: wasi.wasiImport,
+  };
   vm.addToImports(imports);
   const printer = options.consolePrint ?? true ? consolePrinter() : undefined;
   printer?.addToImports(imports);
 
+  {
+    // WORKAROUND: browser_wasi_shim does not support some syscalls yet
+    // and returns -1 instead of proper ERRNO values and it results in confusing
+    // error messages "Success -- /path/to/file".
+    // Update browser_wasi_shim version when my fix[^1] will be released.
+    // [^1]: https://github.com/bjorn3/browser_wasi_shim/commit/6193f7482633ef818604375d9755ded67946adfc
+    const syscalls = imports["wasi_snapshot_preview1"];
+    for (const name of Object.keys(syscalls)) {
+      const original = syscalls[name];
+      syscalls[name] = (...args) => {
+        const result = original(...args);
+        if (result === -1) {
+          return 58; // ENOTSUP
+        }
+        // browser_wasi_shim's `random_get` returns `undefined` on success
+        // instead of `0`.
+        if (result === undefined) {
+          return 0; // Success
+        }
+        return result;
+      };
+    }
+  }
+
   const instance = await WebAssembly.instantiate(rubyModule, imports);
-  wasi.instantiate(instance);
   await vm.setInstance(instance);
 
   printer?.setMemory(instance.exports.memory as WebAssembly.Memory);
 
-  // Manually call `_initialize`, which is a part of reactor model ABI,
-  // because the WASI polyfill doesn't support it yet.
-  (instance.exports._initialize as Function)();
+  wasi.initialize(instance as any);
   vm.initialize();
 
   return {

--- a/packages/npm-packages/ruby-wasm-wasi/src/browser.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/browser.ts
@@ -28,30 +28,6 @@ export const DefaultRubyVM = async (
   const printer = options.consolePrint ?? true ? consolePrinter() : undefined;
   printer?.addToImports(imports);
 
-  {
-    // WORKAROUND: browser_wasi_shim does not support some syscalls yet
-    // and returns -1 instead of proper ERRNO values and it results in confusing
-    // error messages "Success -- /path/to/file".
-    // Update browser_wasi_shim version when my fix[^1] will be released.
-    // [^1]: https://github.com/bjorn3/browser_wasi_shim/commit/6193f7482633ef818604375d9755ded67946adfc
-    const syscalls = imports["wasi_snapshot_preview1"];
-    for (const name of Object.keys(syscalls)) {
-      const original = syscalls[name];
-      syscalls[name] = (...args) => {
-        const result = original(...args);
-        if (result === -1) {
-          return 58; // ENOTSUP
-        }
-        // browser_wasi_shim's `random_get` returns `undefined` on success
-        // instead of `0`.
-        if (result === undefined) {
-          return 0; // Success
-        }
-        return result;
-      };
-    }
-  }
-
   const instance = await WebAssembly.instantiate(rubyModule, imports);
   await vm.setInstance(instance);
 

--- a/packages/npm-packages/ruby-wasm-wasi/src/browser.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/browser.ts
@@ -1,64 +1,6 @@
 import { init, WASI } from "@wasmer/wasi";
 import { RubyVM } from "./index.js";
-
-const consolePrinter = () => {
-  let memory: WebAssembly.Memory | undefined = undefined;
-  let view: DataView | undefined = undefined;
-
-  const decoder = new TextDecoder();
-
-  return {
-    addToImports(imports: WebAssembly.Imports): void {
-      const original = imports.wasi_snapshot_preview1.fd_write as (
-        fd: number,
-        iovs: number,
-        iovsLen: number,
-        nwritten: number,
-      ) => number;
-      imports.wasi_snapshot_preview1.fd_write = (
-        fd: number,
-        iovs: number,
-        iovsLen: number,
-        nwritten: number,
-      ): number => {
-        if (fd !== 1 && fd !== 2) {
-          return original(fd, iovs, iovsLen, nwritten);
-        }
-
-        if (typeof memory === "undefined" || typeof view === "undefined") {
-          throw new Error("Memory is not set");
-        }
-        if (view.buffer.byteLength === 0) {
-          view = new DataView(memory.buffer);
-        }
-
-        const buffers = Array.from({ length: iovsLen }, (_, i) => {
-          const ptr = iovs + i * 8;
-          const buf = view.getUint32(ptr, true);
-          const bufLen = view.getUint32(ptr + 4, true);
-          return new Uint8Array(memory.buffer, buf, bufLen);
-        });
-
-        let written = 0;
-        let str = "";
-        for (const buffer of buffers) {
-          str += decoder.decode(buffer);
-          written += buffer.byteLength;
-        }
-        view.setUint32(nwritten, written, true);
-
-        const log = fd === 1 ? console.log : console.warn;
-        log(str);
-
-        return 0;
-      };
-    },
-    setMemory(m: WebAssembly.Memory) {
-      memory = m;
-      view = new DataView(m.buffer);
-    },
-  };
-};
+import { consolePrinter } from "./console.js";
 
 export const DefaultRubyVM = async (
   rubyModule: WebAssembly.Module,

--- a/packages/npm-packages/ruby-wasm-wasi/src/console.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/console.ts
@@ -1,0 +1,95 @@
+/**
+ * Create a console printer that can be used as an overlay of WASI imports.
+ * See the example below for how to use it.
+ *
+ * ```javascript
+ * const imports = {
+ *  "wasi_snapshot_preview1": wasi.wasiImport,
+ * }
+ * const printer = consolePrinter();
+ * printer.addToImports(imports);
+ *
+ * const instance = await WebAssembly.instantiate(module, imports);
+ * printer.setMemory(instance.exports.memory);
+ * ```
+ *
+ * Note that the `stdout` and `stderr` functions are called with text, not
+ * bytes. This means that bytes written to stdout/stderr will be decoded as
+ * UTF-8 and then passed to the `stdout`/`stderr` functions every time a write
+ * occurs without buffering.
+ *
+ * @param stdout A function that will be called when stdout is written to.
+ *               Defaults to `console.log`.
+ * @param stderr A function that will be called when stderr is written to.
+ *               Defaults to `console.warn`.
+ * @returns An object that can be used as an overlay of WASI imports.
+ */
+export function consolePrinter(
+  {
+    stdout,
+    stderr,
+  }: {
+    stdout: (str: string) => void;
+    stderr: (str: string) => void;
+  } = {
+    stdout: console.log,
+    stderr: console.warn,
+  },
+) {
+  let memory: WebAssembly.Memory | undefined = undefined;
+  let view: DataView | undefined = undefined;
+
+  const decoder = new TextDecoder();
+
+  return {
+    addToImports(imports: WebAssembly.Imports): void {
+      const original = imports.wasi_snapshot_preview1.fd_write as (
+        fd: number,
+        iovs: number,
+        iovsLen: number,
+        nwritten: number,
+      ) => number;
+      imports.wasi_snapshot_preview1.fd_write = (
+        fd: number,
+        iovs: number,
+        iovsLen: number,
+        nwritten: number,
+      ): number => {
+        if (fd !== 1 && fd !== 2) {
+          return original(fd, iovs, iovsLen, nwritten);
+        }
+
+        if (typeof memory === "undefined" || typeof view === "undefined") {
+          throw new Error("Memory is not set");
+        }
+        if (view.buffer.byteLength === 0) {
+          view = new DataView(memory.buffer);
+        }
+
+        const buffers = Array.from({ length: iovsLen }, (_, i) => {
+          const ptr = iovs + i * 8;
+          const buf = view.getUint32(ptr, true);
+          const bufLen = view.getUint32(ptr + 4, true);
+          return new Uint8Array(memory.buffer, buf, bufLen);
+        });
+
+        let written = 0;
+        let str = "";
+        for (const buffer of buffers) {
+          str += decoder.decode(buffer);
+          written += buffer.byteLength;
+        }
+        view.setUint32(nwritten, written, true);
+
+        const log = fd === 1 ? stdout : stderr;
+        log(str);
+
+        return 0;
+      };
+    },
+    setMemory(m: WebAssembly.Memory) {
+      memory = m;
+      view = new DataView(m.buffer);
+    },
+  };
+}

--- a/packages/npm-packages/ruby-wasm-wasi/src/index.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/index.ts
@@ -6,6 +6,8 @@ import {
   JsAbiValue,
 } from "./bindgen/rb-js-abi-host.js";
 
+export { consolePrinter } from "./console.js";
+
 /**
  * A Ruby VM instance
  *

--- a/packages/npm-packages/ruby-wasm-wasi/test-e2e/examples/examples.spec.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/test-e2e/examples/examples.spec.ts
@@ -1,12 +1,18 @@
 import { test, expect, Page } from "@playwright/test";
 import path from "path";
-import { waitForRubyVM, setupDebugLog, setupProxy } from "../support";
+import {
+  waitForRubyVM,
+  setupDebugLog,
+  setupProxy,
+  setupUncaughtExceptionRejection,
+} from "../support";
 import { readFileSync } from "fs";
 import http from "http";
 import https from "https";
 
-test.beforeEach(async ({ context }) => {
+test.beforeEach(async ({ context, page }) => {
   setupDebugLog(context);
+  setupUncaughtExceptionRejection(page);
   if (process.env.RUBY_NPM_PACKAGE_ROOT) {
     setupProxy(context);
   } else {

--- a/packages/npm-packages/ruby-wasm-wasi/test-e2e/support.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/test-e2e/support.ts
@@ -1,4 +1,4 @@
-import { BrowserContext, Page } from "@playwright/test";
+import { BrowserContext, Page, expect } from "@playwright/test";
 import path from "path";
 
 export const waitForRubyVM = async (page: Page) => {

--- a/packages/npm-packages/ruby-wasm-wasi/tools/run-test-unit.mjs
+++ b/packages/npm-packages/ruby-wasm-wasi/tools/run-test-unit.mjs
@@ -5,8 +5,7 @@ import * as browserWasi from "@bjorn3/browser_wasi_shim";
 import fs from "fs/promises";
 import path from "path";
 import * as nodeWasi from "wasi";
-import { RubyVM } from "@ruby/wasm-wasi";
-import { consolePrinter } from "@ruby/wasm-wasi/dist/console";
+import { RubyVM, consolePrinter } from "@ruby/wasm-wasi";
 
 const deriveRubySetup = () => {
   let preopens = {}

--- a/packages/npm-packages/ruby-wasm-wasi/tools/run-test-unit.mjs
+++ b/packages/npm-packages/ruby-wasm-wasi/tools/run-test-unit.mjs
@@ -131,30 +131,6 @@ const instantiateWasmerWasi = async (rootTestFile) => {
   printer.addToImports(imports);
   vm.addToImports(imports);
 
-  {
-    // WORKAROUND: browser_wasi_shim does not support some syscalls yet
-    // and returns -1 instead of proper ERRNO values and it results in confusing
-    // error messages "Success -- /path/to/file".
-    // Update browser_wasi_shim version when my fix[^1] will be released.
-    // [^1]: https://github.com/bjorn3/browser_wasi_shim/commit/6193f7482633ef818604375d9755ded67946adfc
-    const syscalls = imports["wasi_snapshot_preview1"]
-    for (const name of Object.keys(syscalls)) {
-      const original = syscalls[name];
-      syscalls[name] = (...args) => {
-        const result = original(...args);
-        if (result === -1) {
-          return 58; // ENOTSUP
-        }
-        // browser_wasi_shim's `random_get` returns `undefined` on success
-        // instead of `0`.
-        if (result === undefined) {
-          return 0; // Success
-        }
-        return result;
-      };
-    }
-  }
-
   const instance = await WebAssembly.instantiate(rubyModule, imports);
   printer.setMemory(instance.exports.memory);
   await vm.setInstance(instance);


### PR DESCRIPTION
| | `@wasmer/wasi` | `@bjorn3/browser_wasi_shim` |
|:-:|--:|--:|
| Size of `browser.umd.min.js` | 491K | 32K |


TODO

- [x] Check basictest
- [x] Check bootstraptest
- [x] Circular dependency warning
```
(!) Circular dependency
../../../node_modules/@bjorn3/browser_wasi_shim/dist/fs_core.js -> ../../../node_modules/@bjorn3/browser_wasi_shim/dist/fs_fd.js -> ../../../node_modules/@bjorn3/browser_wasi_shim/dist/fs_core.js
```
