### PR TITLE
fix(cheat_sheet): broken links to esm script

### DIFF
--- a/docs/cheat_sheet.md
+++ b/docs/cheat_sheet.md
@@ -51,7 +51,7 @@ If you want to control Ruby VM from JavaScript, you can use `@ruby/wasm-wasi` pa
 ```html
 <html>
   <script type="module">
-    import { DefaultRubyVM } from "https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@2.3.0/dist/esm/browser.js";
+    import { DefaultRubyVM } from "https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@2.3.0/dist/browser.esm.js";
     const response = await fetch("https://cdn.jsdelivr.net/npm/@ruby/3.2-wasm-wasi@2.3.0/dist/ruby+stdlib.wasm");
     const module = await WebAssembly.compileStreaming(response);
     const { vm } = await DefaultRubyVM(module);
@@ -117,7 +117,7 @@ Or using `@ruby/wasm-wasi` package API:
 ```html
 <html>
   <script type="module">
-    import { DefaultRubyVM } from "https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@2.3.0/dist/esm/browser.js";
+    import { DefaultRubyVM } from "https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@2.3.0/dist/browser.esm.js";
     const response = await fetch("https://cdn.jsdelivr.net/npm/@ruby/3.2-wasm-wasi@2.3.0/dist/ruby+stdlib.wasm");
     const module = await WebAssembly.compileStreaming(response);
     const { vm } = await DefaultRubyVM(module);


### PR DESCRIPTION
There might be others that are broken, but I confirmed these broken links work when updated to the new naming structure found in the node package.