### PR TITLE
Add `version: "preview1"` field to Node.js WASI options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1466,9 +1466,10 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "20.8.10",
+            "version": "20.10.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
+            "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -5119,7 +5120,7 @@
                 "@rollup/plugin-node-resolve": "^15.1.0",
                 "@rollup/plugin-typescript": "^11.1.2",
                 "@types/jest": "^29.5.3",
-                "@types/node": "20.8.10",
+                "@types/node": "20.10.4",
                 "jest": "^29.6.2",
                 "prettier": "^3.0.0",
                 "rollup": "^4.6.1",
@@ -6126,7 +6127,7 @@
                 "@rollup/plugin-node-resolve": "^15.1.0",
                 "@rollup/plugin-typescript": "^11.1.2",
                 "@types/jest": "^29.5.3",
-                "@types/node": "20.8.10",
+                "@types/node": "20.10.4",
                 "jest": "^29.6.2",
                 "prettier": "^3.0.0",
                 "rollup": "^4.6.1",
@@ -6246,7 +6247,9 @@
             }
         },
         "@types/node": {
-            "version": "20.8.10",
+            "version": "20.10.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
+            "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
             "dev": true,
             "requires": {
                 "undici-types": "~5.26.4"

--- a/packages/npm-packages/ruby-wasm-wasi/package.json
+++ b/packages/npm-packages/ruby-wasm-wasi/package.json
@@ -58,7 +58,7 @@
     "@rollup/plugin-node-resolve": "^15.1.0",
     "@rollup/plugin-typescript": "^11.1.2",
     "@types/jest": "^29.5.3",
-    "@types/node": "20.8.10",
+    "@types/node": "20.10.4",
     "jest": "^29.6.2",
     "prettier": "^3.0.0",
     "rollup": "^4.6.1",

--- a/packages/npm-packages/ruby-wasm-wasi/src/node.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/node.ts
@@ -5,7 +5,7 @@ export const DefaultRubyVM = async (
   rubyModule: WebAssembly.Module,
   options: { env?: Record<string, string> | undefined } = {},
 ) => {
-  const wasi = new WASI({ env: options.env });
+  const wasi = new WASI({ env: options.env, version: "preview1" });
   const vm = new RubyVM();
   const imports = {
     wasi_snapshot_preview1: wasi.wasiImport,


### PR DESCRIPTION
The field is added in Node.js v19.8.0, and it's mandatory from v20.0.0. We cannot upgrade Node.js version in CI yet due to https://github.com/ruby/ruby.wasm/issues/314, but this change resolves https://github.com/ruby/ruby.wasm/issues/336