### PR TITLE
Add note about installing `rollup` globally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,9 @@ $ rake --tasks
 ## Building and Testing [`ruby-wasm-wasi`](./packages/npm-packages/ruby-wasm-wasi)
 
 ```console
+# Install rollup globally
+# npm install -g rollup
+
 # Download a prebuilt Ruby release (if you don't need to re-build Ruby)
 $ rake build:download_prebuilt
 


### PR DESCRIPTION
Alternatively, it's also enough to install rollup locally and do

export rollup=node_modules/rollup/dist/bin/rollup

Not sure it's worth mentioning though.