### PR TITLE
use gem env user_gemhome instead of system-wide location

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -3,5 +3,8 @@ set -euo pipefail
 IFS=$'\n\t'
 set -vx
 
+export GEM_HOME="$(gem env user_gemhome)"
+export PATH="$PATH:$GEM_HOME/bin"
+
 bundle install
 npm ci


### PR DESCRIPTION
This solves https://github.com/ruby/ruby.wasm/issues/343 by running `bundle install` in the context of `gem env user_gemhome`.