### PR TITLE
Revert "Pin ruby/ruby master version"

### DIFF
--- a/lib/ruby_wasm/packager.rb
+++ b/lib/ruby_wasm/packager.rb
@@ -89,7 +89,7 @@ class RubyWasm::Packager
       "head" => {
         type: "github",
         repo: "ruby/ruby",
-        rev: "997124fc0b7697bb9383e8feb8e1d88017c4bcb8",
+        rev: "master",
         patches: patches.map { |p| File.expand_path(p) }
       },
       "3.3" => {


### PR DESCRIPTION
This reverts commit acf5e12ef25e1045ddced46b8e37e9cab050d627.

The issue has been fixed in https://github.com/ruby/ruby/commit/a4bdf26781c09be9f8b8860d0032e28dbd3bf0b1