### PR TITLE
Build and publish ruby-wasm-wasi on CI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -41,6 +41,10 @@ NPM_PACKAGES = [
     ruby_version: "3.2",
     gemfile: "packages/npm-packages/ruby-wasm-wasi/Gemfile",
     target: "wasm32-unknown-wasi"
+  },
+  {
+    name: "ruby-wasm-wasi",
+    target: "wasm32-unknown-wasi"
   }
 ]
 


### PR DESCRIPTION
The CI job was accidentally removed while I was working on the RubyGems support.