### PR TITLE
Fix broken prebuilt_downloader

### DIFF
--- a/lib/ruby_wasm/build/downloader.rb
+++ b/lib/ruby_wasm/build/downloader.rb
@@ -1,5 +1,15 @@
 module RubyWasm
   class Downloader
+    def format_size(size)
+      units = %w[B KB MB GB TB]
+      unit = 0
+      while size > 1024 and unit < units.size - 1
+        size /= 1024.0
+        unit += 1
+      end
+      "%s #{units[unit]}" % size.round(2)
+    end
+
     def download(url, dest, message)
       require "open-uri"
       content_length = 0
@@ -8,7 +18,7 @@ module RubyWasm
         uri,
         content_length_proc: ->(len) { content_length = len },
         progress_proc: ->(size) do
-          print "\r#{message} (#{SizeFormatter.format(content_length)}) %.2f%%" %
+          print "\r#{message} (#{format_size(content_length)}) %.2f%%" %
                   (size.to_f / content_length * 100)
         end
       ) { |f| File.open(dest, "wb") { |out| out.write f.read } }


### PR DESCRIPTION
I built it as written in CONTRIBUTING.md and got an error on the way.
This line was probably the cause, so I reverted.

https://github.com/ruby/ruby.wasm/commit/647b2eb7fa2b4b7346df11ae809991d1cd802116#diff-fb5ebe2655a98fd7ab64c546f729c3af1c3521d7b9aad6f611f49852228f4b08R11