### PR TITLE
Export *.wasm files in npm packages

### DIFF
--- a/packages/npm-packages/ruby-3.2-wasm-wasi/package.json
+++ b/packages/npm-packages/ruby-3.2-wasm-wasi/package.json
@@ -16,6 +16,12 @@
       "umd": "./dist/umd/*.js",
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js"
+    },
+    "./*.wasm": {
+      "browser": "./*.wasm",
+      "umd": "./*.wasm",
+      "import": "./*.wasm",
+      "require": "./*.wasm"
     }
   },
   "files": [

--- a/packages/npm-packages/ruby-3.3-wasm-wasi/package.json
+++ b/packages/npm-packages/ruby-3.3-wasm-wasi/package.json
@@ -16,6 +16,12 @@
       "umd": "./dist/umd/*.js",
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js"
+    },
+    "./*.wasm": {
+      "browser": "./*.wasm",
+      "umd": "./*.wasm",
+      "import": "./*.wasm",
+      "require": "./*.wasm"
     }
   },
   "files": [

--- a/packages/npm-packages/ruby-head-wasm-wasi/package.json
+++ b/packages/npm-packages/ruby-head-wasm-wasi/package.json
@@ -16,6 +16,12 @@
       "umd": "./dist/umd/*.js",
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js"
+    },
+    "./*.wasm": {
+      "browser": "./*.wasm",
+      "umd": "./*.wasm",
+      "import": "./*.wasm",
+      "require": "./*.wasm"
     }
   },
   "files": [


### PR DESCRIPTION
This PR fixes a problem with shadowing .wasm files via `"exports"`, for example this line raises an error:

```js
import wasmUrl from "@ruby/3.3-wasm-wasi/dist/ruby+stdlib.wasm?url";
```