### PR TITLE
Improve error message on assignment <non-js-like> to JS

### DIFF
--- a/packages/gems/js/ext/js/js-core.c
+++ b/packages/gems/js/ext/js/js-core.c
@@ -201,7 +201,8 @@ static VALUE _rb_js_obj_aset(VALUE obj, VALUE key, VALUE val) {
   struct jsvalue *p = check_jsvalue(obj);
   VALUE rv = _rb_js_try_convert(rb_mJS, val);
   if (rv == Qnil) {
-    rb_raise(rb_eTypeError, "wrong argument type %s (expected JS::Object like object)",
+    rb_raise(rb_eTypeError,
+             "wrong argument type %s (expected JS::Object like object)",
              rb_class2name(rb_obj_class(val)));
   }
   struct jsvalue *v = check_jsvalue(rv);

--- a/packages/gems/js/ext/js/js-core.c
+++ b/packages/gems/js/ext/js/js-core.c
@@ -200,6 +200,9 @@ static VALUE _rb_js_obj_aref(VALUE obj, VALUE key) {
 static VALUE _rb_js_obj_aset(VALUE obj, VALUE key, VALUE val) {
   struct jsvalue *p = check_jsvalue(obj);
   VALUE rv = _rb_js_try_convert(rb_mJS, val);
+  if (rv == Qnil) {
+    rb_raise(rb_eTypeError, "value is not a JS::Object like object");
+  }
   struct jsvalue *v = check_jsvalue(rv);
   rb_js_abi_host_string_t key_abi_str;
   key = rb_obj_as_string(key);

--- a/packages/gems/js/ext/js/js-core.c
+++ b/packages/gems/js/ext/js/js-core.c
@@ -201,7 +201,8 @@ static VALUE _rb_js_obj_aset(VALUE obj, VALUE key, VALUE val) {
   struct jsvalue *p = check_jsvalue(obj);
   VALUE rv = _rb_js_try_convert(rb_mJS, val);
   if (rv == Qnil) {
-    rb_raise(rb_eTypeError, "value is not a JS::Object like object");
+    rb_raise(rb_eTypeError, "wrong argument type %s (expected JS::Object like object)",
+             rb_class2name(rb_obj_class(val)));
   }
   struct jsvalue *v = check_jsvalue(rv);
   rb_js_abi_host_string_t key_abi_str;

--- a/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
+++ b/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
@@ -347,7 +347,7 @@ class JS::TestObject < Test::Unit::TestCase
   end
 
   def test_member_set_with_non_js_object
-    assert_raise_message("value is not a JS::Object like object") do
+    assert_raise_message("wrong argument type Object (expected JS::Object like object)") do
       JS.global[:tmp] = Object.new
     end
   end

--- a/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
+++ b/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
@@ -346,6 +346,12 @@ class JS::TestObject < Test::Unit::TestCase
     assert_equal 41.to_s, object["bar"].to_s
   end
 
+  def test_member_set_with_non_js_object
+    assert_raise_message("value is not a JS::Object like object") do
+      JS.global[:tmp] = Object.new
+    end
+  end
+
   def test_member_set_with_stress_gc
     GC.stress = true
     JS.global[:tmp] = "1"


### PR DESCRIPTION
```ruby
require "js"

JS.global[:document][:body][:innerHTML] = Object.new

# => eval:3:in `[]=': wrong argument type nil (expected jsvalue) (TypeError) eval:3:in `<main>'
```

Hmm this error message is difficult (internal error message?), so rewrited it as `call` method.

https://github.com/ruby/ruby.wasm/blob/647b2eb7fa2b4b7346df11ae809991d1cd802116/packages/gems/js/ext/js/js-core.c#L283-L287