### PR TITLE
Make the emscripten build a bit configurable

### DIFF
--- a/lib/ruby_wasm/build/product/crossruby.rb
+++ b/lib/ruby_wasm/build/product/crossruby.rb
@@ -298,6 +298,10 @@ module RubyWasm
         args << %Q(WASI_SDK_PATH=#{wasi_sdk_path.wasi_sdk_path})
       when "wasm32-unknown-emscripten"
         ldflags.concat(%w[-s MODULARIZE=1])
+        env_emcc_ldflags = ENV["RUBY_WASM_EMCC_LDFLAGS"] || ""
+        unless env_emcc_ldflags.empty?
+          ldflags << env_emcc_ldflags
+        end
       else
         raise "unknown target: #{target}"
       end

--- a/lib/ruby_wasm/cli.rb
+++ b/lib/ruby_wasm/cli.rb
@@ -156,6 +156,10 @@ module RubyWasm
       case options[:profile]
       when "full"
         config[:default_exts] = RubyWasm::Packager::ALL_DEFAULT_EXTS
+        env_additional_exts = ENV["RUBY_WASM_ADDITIONAL_EXTS"] || ""
+        unless env_additional_exts.empty?
+          config[:default_exts] += "," + env_additional_exts
+        end
       when "minimal"
         config[:default_exts] = ""
       else


### PR DESCRIPTION
This changeset introduces two environment variables:

* `RUBY_WASM_EMCC_LDFLAGS` allows to specify additional options to `emcc` for linking.
* `RUBY_WASM_ADDITIONAL_EXTS` allows to specify default exts to be compiled in addition to `RubyWasm::Packager::ALL_DEFAULT_EXTS`.

This should allow for experimental linking with xterm-pty.

```
RUBY_WASM_ADDITIONAL_EXTS=io/console,io/wait RUBY_WASM_EMCC_LDFLAGS="-sASYNCIFY --js-library /home/mame/work/xterm-pty/emscripten-pty.js" rake npm:ruby-head-wasm-emscripten:build
```