### PR TITLE
Prevent a warning in ruby-wasm-emscripten/build-package.sh

### DIFF
--- a/packages/npm-packages/ruby-wasm-emscripten/build-package.sh
+++ b/packages/npm-packages/ruby-wasm-emscripten/build-package.sh
@@ -18,7 +18,7 @@ find_compatible_node() {
     # Find `node` executable (>= 15) in PATH
     IFS=':' read -ra dirs <<< "$PATH"
     for dir in "${dirs[@]}"; do
-        if [ -x "$dir/node" ]; then
+        if [ -f "$dir/node" ] && [ -x "$dir/node" ]; then
             node_version=$("$dir/node" --version)
             if [ "${node_version:1:2}" -ge 15 ]; then
                 echo "$dir/node"


### PR DESCRIPTION
The PATH environment variable introduced emsdk has a directory named `node`, which caused the following error:

```
./build-package.sh: line 22: /home/runner/work/emirb/emirb/emsdk/node: Is a directory
./build-package.sh: line 23: [: : integer expression expected
```

This change checks the version of "$dir/node" only when it is a file, not a directory.