### PR TITLE
Use jsDelivr instead of git.savannah.gnu.org

### DIFF
--- a/lib/ruby_wasm/build/product/libyaml.rb
+++ b/lib/ruby_wasm/build/product/libyaml.rb
@@ -52,11 +52,11 @@ module RubyWasm
       executor.system "curl",
                       "-o",
                       "#{product_build_dir}/config/config.guess",
-                      "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD"
+                      "https://cdn.jsdelivr.net/gh/gcc-mirror/gcc@master/config.guess"
       executor.system "curl",
                       "-o",
                       "#{product_build_dir}/config/config.sub",
-                      "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD"
+                      "https://cdn.jsdelivr.net/gh/gcc-mirror/gcc@master/config.sub"
 
       executor.system "./configure", *configure_args, chdir: product_build_dir
       executor.system "make",

--- a/lib/ruby_wasm/packager.rb
+++ b/lib/ruby_wasm/packager.rb
@@ -84,6 +84,7 @@ class RubyWasm::Packager
 
   # Retrieves the alias definitions for the Ruby sources.
   def self.build_source_aliases(root)
+    # @type var sources: Hash[string, RubyWasm::Packager::build_source]
     sources = {
       "head" => {
         type: "github",

--- a/sig/ruby_wasm/packager.rbs
+++ b/sig/ruby_wasm/packager.rbs
@@ -17,7 +17,7 @@ class RubyWasm::Packager
 
   def root: () -> string
 
-  type build_source = Hash[Symbol, (String | Array[String])]
+  type build_source = Hash[Symbol, (string | Array[String])]
   def self.build_source_aliases: (string root) -> Hash[string, build_source]
 
   ALL_DEFAULT_EXTS: string


### PR DESCRIPTION
Somehow git.savannah.gnu.org is down now, so I'm using jsDelivr mirror instead as ruby/ruby does.