### PR TITLE
specialize `ArrayBuffer#to_s` and return ASCII-8BIT data

### DIFF
--- a/packages/npm-packages/ruby-wasm-wasi/src/bindgen/rb-js-abi-host.js
+++ b/packages/npm-packages/ruby-wasm-wasi/src/bindgen/rb-js-abi-host.js
@@ -69,9 +69,17 @@ export function addRbJsAbiHostToImports(imports, obj, get_export) {
   imports["rb-js-abi-host"]["js-value-to-string: func(value: handle<js-abi-value>) -> string"] = function(arg0, arg1) {
     const memory = get_export("memory");
     const realloc = get_export("cabi_realloc");
-    const ret0 = obj.jsValueToString(resources0.get(arg0));
-    const ptr0 = utf8_encode(ret0, realloc, memory);
-    const len0 = UTF8_ENCODED_LEN;
+    let ret0, ptr0, len0;
+    ret0 = resources0.get(arg0);
+    if (ret0 instanceof ArrayBuffer) {
+      ptr0 = realloc(0, 0, 1, ret0.byteLength);
+      len0 = ret0.byteLength;
+      new Uint8Array(memory.buffer).set(new Uint8Array(ret0), ptr0);
+    } else {
+      ret0 = obj.jsValueToString(ret0);
+      ptr0 = utf8_encode(ret0, realloc, memory);
+      len0 = UTF8_ENCODED_LEN;
+    }
     data_view(memory).setInt32(arg1 + 4, len0, true);
     data_view(memory).setInt32(arg1 + 0, ptr0, true);
   };


### PR DESCRIPTION
To fix #342 , specialize `ArrayBuffer#to_s` and return ASCII-8BIT data.

Usage:

```ruby
require "js"

response = JS.global.fetch("<dumped buffer's url>").await
puts response[:status]

arraybuffer = response.arrayBuffer.await

Marshal.load(arraybuffer.to_s) # we can Marshal.load now!
```

Of course this is destructive, but no one will spare the old behavior since the current to_s always returns [object ArrayBuffer] and is useless.