### PR TITLE
Use `ruby -C` instead of `chdir` in Kernel#system

### DIFF
--- a/lib/ruby_wasm/build/product/crossruby.rb
+++ b/lib/ruby_wasm/build/product/crossruby.rb
@@ -72,9 +72,6 @@ module RubyWasm
         # HACK: extout is required to find config.h
         "-e",
         %Q($extout="#{crossruby.build_dir}/.ext"),
-        # HACK: skip have_devel check since ruby is not installed yet
-        "-e",
-        "$have_devel = true",
         # HACK: force static ext build by imitating extmk
         "-e",
         "$static = true; trace_var(:$static) {|v| $static = true }",

--- a/lib/ruby_wasm/build/product/crossruby.rb
+++ b/lib/ruby_wasm/build/product/crossruby.rb
@@ -64,6 +64,7 @@ module RubyWasm
       objdir = product_build_dir crossruby
       source = crossruby.source
       extconf_args = [
+        "-C", objdir,
         "--disable=gems",
         # HACK: top_srcdir is required to find ruby headers
         "-e",
@@ -93,7 +94,6 @@ module RubyWasm
       # Clear RUBYOPT to avoid loading unrelated bundle setup
       executor.system crossruby.baseruby_path,
                       *extconf_args,
-                      chdir: objdir,
                       env: {
                         "RUBYOPT" => ""
                       }


### PR DESCRIPTION
To allow developers to use console-printed commands without cd'ing into the build directory.