### PR TITLE
Add create_promise method to JS module

### DIFF
--- a/packages/gems/js/lib/js.rb
+++ b/packages/gems/js/lib/js.rb
@@ -102,6 +102,41 @@ module JS
     @promise_scheduler
   end
 
+  # Initialize the Promise with a block.
+  #
+  # == Example
+  #
+  #   promise = JS.create_promise do |resolve, reject|
+  #     # Calling JavaScript functions from ruby requires a receiver.
+  #     reciever = JS.global[:Object].new
+  #     reciever[:resolve] = resolve
+  #
+  #     # Resolve the promise with the value 42
+  #     reciever.resolve(42)
+  #   end
+  #
+  # This function can be used in combination with the setTimeout function
+  # to stop processing for an arbitrary amount of time.
+  #
+  # == Example
+  #
+  #   promise = JS.create_promise { JS.global.setTimeout(_1, 1000) }
+  #   promise.await # Sleep for 1 second
+  #   puts "Hello, world!"
+  #
+  # Initially, the JS::Object#new method accepts a block to pass a callback function
+  # to the constructor of any JavaScript object.
+  # However, JavaScript objects other than Promise could not prevent nested VM operations
+  # that occur when the callback function is called.
+  # So we defined a function to initialize Promise.
+  def self.create_promise(&executer)
+    unless block_given?
+      raise ArgumentError, "To initialize a Promise, specify a block"
+    end
+
+    JS.global[:Reflect].construct JS.global[:Promise], [executer].to_js
+  end
+
   private
 
   def self.__eval_async_rb(rb_code, future)

--- a/packages/npm-packages/ruby-wasm-wasi/test/unit/test_js.rb
+++ b/packages/npm-packages/ruby-wasm-wasi/test/unit/test_js.rb
@@ -34,4 +34,19 @@ class JS::TestJS < Test::Unit::TestCase
     assert_equal "true", JS::True.to_s
     assert_equal "false", JS::False.to_s
   end
+
+  def test_create_promise
+    promise =
+      JS.create_promise do
+        reciever = JS.global[:Object].new
+        reciever[:resolve] = _1
+        reciever.resolve(42)
+      end
+    assert_equal 42, promise.await.to_i
+  end
+
+  def test_create_promise_with_set_timeout_function
+    assert_equal JS::Undefined.to_s,
+                 JS.create_promise { JS.global.setTimeout(_1, 0) }.await.to_s
+  end
 end


### PR DESCRIPTION
## Motivation
Cannot pass block to `JS::Object#new` method. Therefore, to initialize a Promise object by passing a callback function to it, we must use `JS.eval` as follows:

```ruby
JS.eval("return new Promise((resolve) => setTimeout(resolve, 1000))")
```

With this function, we can write

```ruby
JS.create_promise { JS.global.setTimeout(_1, 0) }
```

This makes it easy to implement a browser-activated [Kernel.#sleep](https://docs.ruby-lang.org/ja/latest/method/Kernel/m/sleep.html).

```ruby
module Kernel
  def sleep(time) = JS.create_promise { JS.global.setTimeout(_1, time * 1000) }.await
end
```

## Reason for change in implementation

Initially, I tried to have the JS::Object#new method accept a block and pass the callback function to the constructor of the JavaScript object. However, I could not prevent the nested VM operations that occur when the callback function is called on any JavaScript object other than Promise.

> RbFatalError: Ruby Fatal Error: Ruby APIs that may rewind the VM stack are prohibited under nested VM operation (rb_wasm_handle_fiber_unwind)
Nested VM operation means that the call stack has sandwitched JS frames like JS -> Ruby -> JS -> Ruby caused by something like `window.rubyVM.eval("JS.global[:rubyVM].eval('Fiber.yield')")`

Therefore, I defined a function to initialize Promise.
