### PR TITLE
[wasm-pic] Explicitly pass `asyncify-ignore-imports` for non-pic builds

### DIFF
--- a/lib/ruby_wasm/packager/core.rb
+++ b/lib/ruby_wasm/packager/core.rb
@@ -209,7 +209,9 @@ class RubyWasm::Packager::Core
       # script of Ruby.
       if @packager.full_build_options[:target] != "wasm32-unknown-emscripten"
         build.crossruby.debugflags = %w[-g]
-        build.crossruby.wasmoptflags = %w[-O3 -g]
+        # We assume that imported functions provided through WASI will not change
+        # asyncify state, so we ignore them.
+        build.crossruby.wasmoptflags = %w[-O3 -g --pass-arg=asyncify-ignore-imports]
         build.crossruby.ldflags = %w[
           -Xlinker
           --stack-first


### PR DESCRIPTION
`configure.ac` had been passing `--pass-arg=asyncify-ignore-imports` to wasm-opt by default, but we cannot use it for dynamic linking builds because dynamic library can call Ruby's asyncified functions, so we cannot assume that all imported dynamically linked functions do not change asyncify state.
Therefore `configure.ac` removed the default `--pass-arg=asyncify-ignore-imports`. We can still use it for non-pic builds, so we explicitly pass it for non-pic builds.