### PR TITLE
Include Ruby exception message in VM interleaving error

### DIFF
--- a/packages/npm-packages/ruby-wasm-wasi/src/vm.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/vm.ts
@@ -137,8 +137,7 @@ export class RubyVM {
         const str = new TextDecoder().decode(
           new Uint8Array(memory.buffer, messagePtr, messageLen),
         );
-        throw new RbFatalError(
-          "Ruby APIs that may rewind the VM stack are prohibited under nested VM operation " +
+        let message = "Ruby APIs that may rewind the VM stack are prohibited under nested VM operation " +
             `(${str})\n` +
             "Nested VM operation means that the call stack has sandwitched JS frames like JS -> Ruby -> JS -> Ruby " +
             "caused by something like `window.rubyVM.eval(\"JS.global[:rubyVM].eval('Fiber.yield')\")`\n" +
@@ -148,8 +147,13 @@ export class RubyVM {
             "     Note that `evalAsync` JS API switches fibers internally\n" +
             "  2. Raising uncaught exceptions\n" +
             "     Please catch all exceptions inside the nested operation\n" +
-            "  3. Calling Continuation APIs\n",
-        );
+            "  3. Calling Continuation APIs\n";
+
+        const error = new RbValue(this.guest.rbErrinfo(), this, this.privateObject());
+        if (error.call("nil?").toString() === "false") {
+          message += "\n" + this.exceptionFormatter.format(error, this, this.privateObject());
+        }
+        throw new RbFatalError(message);
       },
     };
     // NOTE: The GC may collect objects that are still referenced by Wasm


### PR DESCRIPTION
This would help debugging the nested VM operation error.

e.g. 
```
RbFatalError: Ruby Fatal Error: Ruby APIs that may rewind the VM stack are prohibited under nested VM operation (rb_wasm_handle_jmp_unwind)
Nested VM operation means that the call stack has sandwitched JS frames like JS -> Ruby -> JS -> Ruby caused by something like `window.rubyVM.eval("JS.global[:rubyVM].eval('Fiber.yield')")`

Please check your call stack and make sure that you are **not** doing any of the following inside the nested Ruby frame:
  1. Switching fibers (e.g. Fiber#resume, Fiber.yield, and Fiber#transfer)
     Note that `evalAsync` JS API switches fibers internally
  2. Raising uncaught exceptions
     Please catch all exceptions inside the nested operation
  3. Calling Continuation APIs

/bundle/gems/js-2.5.0/lib/js.rb:180:in 'JS::Object#method_missing': undefined method '+' for an instance of JS::Object (NoMethodError)
/__root__/test/unit/test_object.rb:254:in 'block in JS::TestObject#test_new_with_block'
/bundle/gems/js-2.5.0/lib/js.rb:178:in 'JS::Object#call'
/bundle/gems/js-2.5.0/lib/js.rb:178:in 'JS::Object#method_missing'
/bundle/gems/js-2.5.0/lib/js.rb:144:in 'JS::Object#new'
/__root__/test/unit/test_object.rb:254:in 'JS::TestObject#test_new_with_block'
/usr/local/lib/ruby/gems/3.4.0+0/gems/test-unit-3.6.1/lib/test/unit/testcase.rb:871:in 'Test::Unit::TestCase#run_test'
/usr/local/lib/ruby/gems/3.4.0+0/gems/test-unit-3.6.1/lib/test/unit/testcase.rb:566:in 'block (2 levels) in Test::Unit::TestCase#run'
/usr/local/lib/ruby/gems/3.4.0+0/gems/test-unit-3.6.1/lib/test/unit/fixture.rb:276:in 'block in Test::Unit::Fixture#create_fixtures_runner'
/usr/local/lib/ruby/gems/3.4.0+0/gems/test-unit-3.6.1/lib/test/unit/fixture.rb:276:in 'block in Test::Unit::Fixture#create_fixtures_runner'
/usr/local/lib/ruby/gems/3.4.0+0/gems/test-unit-3.6.1/lib/test/unit/fixture.rb:257:in 'Test::Unit::Fixture#run_fixture'
/usr/local/lib/ruby/gems/3.4.0+0/gems/test-unit-3.6.1/lib/test/unit/fixture.rb:292:in 'Test::Unit::Fixture#run_setup'
/usr/local/lib/ruby/gems/3.4.0+0/gems/test-unit-3.6.1/lib/test/unit/testcase.rb:564:in 'block in Test::Unit::TestCase#run'
/usr/local/lib/ruby/gems/3.4.0+0/gems/test-unit-3.6.1/lib/test/unit/testcase.rb:563:in 'Kernel#catch'
/usr/local/lib/ruby/gems/3.4.0+0/gems/test-unit-3.6.1/lib/test/unit/testcase.rb:563:in 'Test::Unit::TestCase#run'
/usr/local/lib/ruby/gems/3.4.0+0/gems/test-unit-3.6.1/lib/test/unit/testsuite.rb:124:in 'Test::Unit::TestSuite#run_test'
/usr/local/lib/ruby/gems/3.4.0+0/gems/test-unit-3.6.1/lib/test/unit/testsuite.rb:53:in 'Test::Unit::TestSuite#run'
/usr/local/lib/ruby/gems/3.4.0+0/gems/test-unit-3.6.1/lib/test/unit/testsuite.rb:124:in 'Test::Unit::TestSuite#run_test'
/usr/local/lib/ruby/gems/3.4.0+0/gems/test-unit-3.6.1/lib/test/unit/testsuite.rb:53:in 'Test::Unit::TestSuite#run'
```