### PR TITLE
Accept block in `JS::Object.new`

### DIFF
--- a/packages/gems/js/lib/js.rb
+++ b/packages/gems/js/lib/js.rb
@@ -137,8 +137,10 @@ class JS::Object
   #   JS.global[:Date].new(2020, 1, 1)
   #   JS.global[:Error].new("error message")
   #   JS.global[:URLSearchParams].new(JS.global[:location][:search])
+  #   JS.global[:Promise].new ->(resolve, reject) { resolve.call(42) }
   #
-  def new(*args)
+  def new(*args, &block)
+    args = args + [block] if block
     JS.global[:Reflect].construct(self, args.to_js)
   end
 


### PR DESCRIPTION
This change allows to pass a block to `JS::Object.new` method. The block will be converted to a function and passed as the last argument to the constructor.

This idea was originally proposed by @ledsun in https://github.com/ruby/ruby.wasm/pull/393