### PR TITLE
Build openssl extension in baseruby correctly

### DIFF
--- a/builders/wasm32-unknown-emscripten/Dockerfile
+++ b/builders/wasm32-unknown-emscripten/Dockerfile
@@ -11,6 +11,7 @@ RUN set -eux; \
   apt-get update; \
   apt-get install ruby ruby-dev ruby-bundler nodejs \
     bison make autoconf git curl build-essential \
+    pkg-config libssl-dev \
     libyaml-dev zlib1g-dev gosu \
     libclang-13-dev -y; \
   apt-get clean; \

--- a/builders/wasm32-unknown-wasi/Dockerfile
+++ b/builders/wasm32-unknown-wasi/Dockerfile
@@ -12,6 +12,7 @@ RUN set -eux; \
   apt-get update; \
   apt-get install ruby ruby-dev ruby-bundler nodejs \
     bison make autoconf git curl build-essential \
+    pkg-config libssl-dev \
     libyaml-dev zlib1g-dev gosu \
     libclang-13-dev -y; \
   apt-get clean; \

--- a/lib/ruby_wasm/cli.rb
+++ b/lib/ruby_wasm/cli.rb
@@ -116,10 +116,6 @@ module RubyWasm
             options[:format] = format
           end
 
-          opts.on("--gemfile GEMFILE", "Gemfile") do |gemfile|
-            options[:gemfile] = gemfile
-          end
-
           opts.on("--print-ruby-cache-key", "Print Ruby cache key") do
             options[:print_ruby_cache_key] = true
           end
@@ -289,12 +285,7 @@ module RubyWasm
           level = options[:print_ruby_cache_key] ? :silent : Bundler.ui.level
           old_level = Bundler.ui.level
           Bundler.ui.level = level
-          if options[:gemfile]
-            Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", options[:gemfile]
-            definition = Bundler.definition(true) # unlock=true to re-evaluate "BUNDLE_GEMFILE"
-          else
-            definition = Bundler.definition
-          end
+          definition = Bundler.definition
         ensure
           Bundler.ui.level = old_level
         end

--- a/lib/ruby_wasm/cli.rb
+++ b/lib/ruby_wasm/cli.rb
@@ -162,7 +162,7 @@ module RubyWasm
       config = { target: options[:target_triplet], src: compute_build_source(options) }
       case options[:profile]
       when "full"
-        config[:default_exts] = RubyWasm::Packager::ALL_DEFAULT_EXTS
+        config[:default_exts] = config[:src][:all_default_exts]
         env_additional_exts = ENV["RUBY_WASM_ADDITIONAL_EXTS"] || ""
         unless env_additional_exts.empty?
           config[:default_exts] += "," + env_additional_exts
@@ -211,15 +211,18 @@ module RubyWasm
         "head" => {
           type: "github",
           repo: "ruby/ruby",
-          rev: "master"
+          rev: "master",
+          all_default_exts: RubyWasm::Packager::ALL_DEFAULT_EXTS,
         },
         "3.3" => {
           type: "tarball",
-          url: "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0.tar.gz"
+          url: "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0.tar.gz",
+          all_default_exts: "bigdecimal,cgi/escape,continuation,coverage,date,dbm,digest/bubblebabble,digest,digest/md5,digest/rmd160,digest/sha1,digest/sha2,etc,fcntl,fiber,gdbm,json,json/generator,json/parser,nkf,objspace,pathname,psych,racc/cparse,rbconfig/sizeof,ripper,stringio,strscan,monitor,zlib,openssl",
         },
         "3.2" => {
           type: "tarball",
-          url: "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.3.tar.gz"
+          url: "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.3.tar.gz",
+          all_default_exts: "bigdecimal,cgi/escape,continuation,coverage,date,dbm,digest/bubblebabble,digest,digest/md5,digest/rmd160,digest/sha1,digest/sha2,etc,fcntl,fiber,gdbm,json,json/generator,json/parser,nkf,objspace,pathname,psych,racc/cparse,rbconfig/sizeof,ripper,stringio,strscan,monitor,zlib,openssl",
         }
       }
 

--- a/lib/ruby_wasm/packager.rb
+++ b/lib/ruby_wasm/packager.rb
@@ -67,7 +67,7 @@ class RubyWasm::Packager
   end
 
   ALL_DEFAULT_EXTS =
-    "bigdecimal,cgi/escape,continuation,coverage,date,dbm,digest/bubblebabble,digest,digest/md5,digest/rmd160,digest/sha1,digest/sha2,etc,fcntl,fiber,gdbm,json,json/generator,json/parser,nkf,objspace,pathname,psych,racc/cparse,rbconfig/sizeof,ripper,stringio,strscan,monitor,zlib,openssl"
+    "cgi/escape,continuation,coverage,date,digest/bubblebabble,digest,digest/md5,digest/rmd160,digest/sha1,digest/sha2,etc,fcntl,json,json/generator,json/parser,objspace,pathname,psych,rbconfig/sizeof,ripper,stringio,strscan,monitor,zlib,openssl"
 
   # Retrieves the build options used for building Ruby itself.
   def build_options

--- a/packages/npm-packages/ruby-wasm-wasi/Gemfile
+++ b/packages/npm-packages/ruby-wasm-wasi/Gemfile
@@ -4,3 +4,5 @@ source "https://rubygems.org"
 
 gem "js", path: "../../gems/js"
 gem "ruby_wasm", path: "../../../"
+gem "power_assert"
+gem "test-unit"

--- a/packages/npm-packages/ruby-wasm-wasi/Gemfile.lock
+++ b/packages/npm-packages/ruby-wasm-wasi/Gemfile.lock
@@ -11,6 +11,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    power_assert (2.0.3)
+    test-unit (3.6.2)
+      power_assert
 
 PLATFORMS
   ruby
@@ -18,7 +21,9 @@ PLATFORMS
 
 DEPENDENCIES
   js!
+  power_assert
   ruby_wasm!
+  test-unit
 
 BUNDLED WITH
    2.5.3

--- a/packages/npm-packages/ruby-wasm-wasi/src/vm.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/vm.ts
@@ -602,7 +602,7 @@ class RbExceptionFormatter {
     }
 
     try {
-      message = error.toString();
+      message = error.call("message").toString();
     } catch (e) {
       message = "unknown";
     }

--- a/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
+++ b/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
@@ -37,7 +37,8 @@ class JS::TestObject < Test::Unit::TestCase
     assert_equal true, JS.eval("return 42;").eql?(42)
     assert_equal false, JS.eval("return 42;") != 42
     # Compare with non JS::Object like object
-    assert_equal false, JS.eval("return 42;") != Object.new
+    assert_equal false, JS.eval("return 42;") == Object.new
+    assert_equal true, JS.eval("return 42;") != Object.new
   end
 
   def assert_object_strictly_eql?(result, a, b)

--- a/packages/npm-packages/ruby-wasm-wasi/tools/run-test-unit.mjs
+++ b/packages/npm-packages/ruby-wasm-wasi/tools/run-test-unit.mjs
@@ -151,7 +151,8 @@ const test = async (instantiate) => {
   await vm.evalAsync(`
     require 'test/unit'
     require_relative '${rootTestFile}'
-    Test::Unit::AutoRunner.run
+    ok = Test::Unit::AutoRunner.run
+    exit(1) unless ok
   `);
 };
 


### PR DESCRIPTION
Because the openssl extension is now required to build Ruby from source.