### PR TITLE
Rename `wasm32-unknown-wasi` to `wasm32-unknown-wasip1` in the build system

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         entry:
-          - { target: wasm32-unknown-wasi }
+          - { target: wasm32-unknown-wasip1 }
           - { target: wasm32-unknown-emscripten }
     runs-on: ubuntu-20.04
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ $ rake --tasks
 $ rake build:download_prebuilt
 
 # Build Ruby (if you need to build Ruby by yourself)
-$ rake build:head-wasm32-unknown-wasi-full
+$ rake build:head-wasm32-unknown-wasip1-full
 
 # Build npm package
 $ rake npm:ruby-head-wasm-wasi
@@ -48,15 +48,15 @@ To select a build profile, see [profiles section in README](https://github.com/r
 
 ```console
 # Build only a specific combination of ruby version, profile, and target
-$ rake build:head-wasm32-unknown-wasi-full
+$ rake build:head-wasm32-unknown-wasip1-full
 # Clean up the build directory
-$ rake build:head-wasm32-unknown-wasi-full:clean
+$ rake build:head-wasm32-unknown-wasip1-full:clean
 # Force to re-execute "make install"
-$ rake build:head-wasm32-unknown-wasi-full:remake
+$ rake build:head-wasm32-unknown-wasip1-full:remake
 
 # Output is in the `rubies` directory
-$ tree -L 3 rubies/head-wasm32-unknown-wasi-full
-rubies/head-wasm32-unknown-wasi-full/
+$ tree -L 3 rubies/head-wasm32-unknown-wasip1-full
+rubies/head-wasm32-unknown-wasip1-full/
 ├── usr
 │   └── local
 │       ├── bin

--- a/README.md
+++ b/README.md
@@ -40,18 +40,18 @@ Dependencies: [wasmtime](https://github.com/bytecodealliance/wasmtime)
 ```console
 $ gem install ruby_wasm
 # Download a prebuilt Ruby release
-$ curl -LO https://github.com/ruby/ruby.wasm/releases/latest/download/ruby-3.3-wasm32-unknown-wasi-full.tar.gz
-$ tar xfz ruby-3.3-wasm32-unknown-wasi-full.tar.gz
+$ curl -LO https://github.com/ruby/ruby.wasm/releases/latest/download/ruby-3.3-wasm32-unknown-wasip1-full.tar.gz
+$ tar xfz ruby-3.3-wasm32-unknown-wasip1-full.tar.gz
 
 # Extract ruby binary not to pack itself
-$ mv ruby-3.3-wasm32-unknown-wasi-full/usr/local/bin/ruby ruby.wasm
+$ mv ruby-3.3-wasm32-unknown-wasip1-full/usr/local/bin/ruby ruby.wasm
 
 # Put your app code
 $ mkdir src
 $ echo "puts 'Hello'" > src/my_app.rb
 
 # Pack the whole directory under /usr and your app dir
-$ rbwasm pack ruby.wasm --dir ./src::/src --dir ./ruby-3.3-wasm32-unknown-wasi-full/usr::/usr -o my-ruby-app.wasm
+$ rbwasm pack ruby.wasm --dir ./src::/src --dir ./ruby-3.3-wasm32-unknown-wasip1-full/usr::/usr -o my-ruby-app.wasm
 
 # Run the packed scripts
 $ wasmtime my-ruby-app.wasm /src/my_app.rb
@@ -110,8 +110,8 @@ A _build_ is a combination of ruby version, _profile_, and _target_.
   </thead>
   <tbody>
     <tr>
-      <td><code>wasm32-unknown-wasi</code></td>
-      <td>Targeting WASI-compatible environments (e.g. Node.js, browsers with polyfill, <a href="https://github.com/bytecodealliance/wasmtime">wasmtime</a>, and so on)</td>
+      <td><code>wasm32-unknown-wasip1</code></td>
+      <td>Targeting [WASI Preview1](https://github.com/WebAssembly/WASI/tree/main/legacy/preview1)-compatible environments (e.g. Node.js, browsers with polyfill, <a href="https://github.com/bytecodealliance/wasmtime">wasmtime</a>, and so on)</td>
     </tr>
     <tr>
       <td><code>wasm32-unknown-emscripten</code></td>

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ A _build_ is a combination of ruby version, _profile_, and _target_.
   <tbody>
     <tr>
       <td><code>wasm32-unknown-wasip1</code></td>
-      <td>Targeting [WASI Preview1](https://github.com/WebAssembly/WASI/tree/main/legacy/preview1)-compatible environments (e.g. Node.js, browsers with polyfill, <a href="https://github.com/bytecodealliance/wasmtime">wasmtime</a>, and so on)</td>
+      <td>Targeting <a href="https://github.com/WebAssembly/WASI/tree/main/legacy/preview1">WASI Preview1</a> compatible environments (e.g. Node.js, browsers with polyfill, <a href="https://github.com/bytecodealliance/wasmtime">wasmtime</a>, and so on)</td>
     </tr>
     <tr>
       <td><code>wasm32-unknown-emscripten</code></td>

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ BUILD_PROFILES = %w[full minimal]
 BUILDS =
   BUILD_SOURCES
     .product(BUILD_PROFILES)
-    .map { |src, profile| [src, "wasm32-unknown-wasi", profile] } +
+    .map { |src, profile| [src, "wasm32-unknown-wasip1", profile] } +
     BUILD_SOURCES.map { |src| [src, "wasm32-unknown-emscripten", "full"] }
 
 NPM_PACKAGES = [
@@ -29,26 +29,26 @@ NPM_PACKAGES = [
     name: "ruby-head-wasm-wasi",
     ruby_version: "head",
     gemfile: "packages/npm-packages/ruby-wasm-wasi/Gemfile",
-    target: "wasm32-unknown-wasi"
+    target: "wasm32-unknown-wasip1"
   },
   {
     name: "ruby-3.3-wasm-wasi",
     ruby_version: "3.3",
     gemfile: "packages/npm-packages/ruby-wasm-wasi/Gemfile",
-    target: "wasm32-unknown-wasi"
+    target: "wasm32-unknown-wasip1"
   },
   {
     name: "ruby-3.2-wasm-wasi",
     ruby_version: "3.2",
     gemfile: "packages/npm-packages/ruby-wasm-wasi/Gemfile",
-    target: "wasm32-unknown-wasi"
+    target: "wasm32-unknown-wasip1"
   },
-  { name: "ruby-wasm-wasi", target: "wasm32-unknown-wasi" }
+  { name: "ruby-wasm-wasi", target: "wasm32-unknown-wasip1" }
 ]
 
 STANDALONE_PACKAGES = [
-  { name: "ruby", build: "head-wasm32-unknown-wasi-full" },
-  { name: "irb", build: "head-wasm32-unknown-wasi-full" }
+  { name: "ruby", build: "head-wasm32-unknown-wasip1-full" },
+  { name: "irb", build: "head-wasm32-unknown-wasip1-full" }
 ]
 
 LIB_ROOT = File.dirname(__FILE__)

--- a/builders/wasm32-unknown-wasip1
+++ b/builders/wasm32-unknown-wasip1
@@ -1,0 +1,1 @@
+wasm32-unknown-wasi

--- a/lib/ruby_wasm/build/product/crossruby.rb
+++ b/lib/ruby_wasm/build/product/crossruby.rb
@@ -293,7 +293,7 @@ module RubyWasm
       args << %Q(--with-baseruby=#{baseruby_path})
 
       case target
-      when "wasm32-unknown-wasi"
+      when /^wasm32-unknown-wasi/
         xldflags << @wasi_vfs.lib_wasi_vfs_a if @wasi_vfs
         # TODO: Find a way to force cast or update API
         # @type var wasi_sdk_path: untyped

--- a/lib/ruby_wasm/build/product/openssl.rb
+++ b/lib/ruby_wasm/build/product/openssl.rb
@@ -42,7 +42,7 @@ module RubyWasm
         --libdir=lib
         -Wl,--allow-undefined
       ]
-      if @target.triple == "wasm32-unknown-wasi"
+      if @target.triple.start_with?("wasm32-unknown-wasi")
         args.concat %w[
                       -D_WASI_EMULATED_SIGNAL
                       -D_WASI_EMULATED_PROCESS_CLOCKS

--- a/lib/ruby_wasm/build/product/product.rb
+++ b/lib/ruby_wasm/build/product/product.rb
@@ -13,7 +13,7 @@ module RubyWasm
     def system_triplet_args
       args = []
       case @target.triple
-      when "wasm32-unknown-wasi"
+      when /^wasm32-unknown-wasi/
         args.concat(%W[--host wasm32-wasi])
       when "wasm32-unknown-emscripten"
         args.concat(%W[--host wasm32-emscripten])

--- a/lib/ruby_wasm/build/product/wasi_vfs.rb
+++ b/lib/ruby_wasm/build/product/wasi_vfs.rb
@@ -12,7 +12,7 @@ module RubyWasm
     def lib_product_build_dir
       File.join(
         @build_dir,
-        "wasm32-unknown-wasi",
+        "wasm32-unknown-wasip1",
         "wasi-vfs-#{WASI_VFS_VERSION}"
       )
     end

--- a/lib/ruby_wasm/build/toolchain.rb
+++ b/lib/ruby_wasm/build/toolchain.rb
@@ -18,7 +18,7 @@ module RubyWasm
 
     def self.get(target, build_dir = nil)
       case target
-      when "wasm32-unknown-wasi"
+      when /^wasm32-unknown-wasi/
         return RubyWasm::WASISDK.new(build_dir: build_dir)
       when "wasm32-unknown-emscripten"
         return RubyWasm::Emscripten.new

--- a/lib/ruby_wasm/cli.rb
+++ b/lib/ruby_wasm/cli.rb
@@ -50,7 +50,7 @@ module RubyWasm
         reconfigure: false,
         clean: false,
         ruby_version: "3.3",
-        target_triplet: "wasm32-unknown-wasi",
+        target_triplet: "wasm32-unknown-wasip1",
         profile: "full",
         stdlib: true,
         disable_gems: false,

--- a/lib/ruby_wasm/packager.rb
+++ b/lib/ruby_wasm/packager.rb
@@ -35,7 +35,7 @@ class RubyWasm::Packager
     fs.remove_non_runtime_files(executor)
     fs.remove_stdlib(executor) unless options[:stdlib]
 
-    if full_build_options[:target] == "wasm32-unknown-wasi" && !support_dynamic_linking?
+    if full_build_options[:target] == "wasm32-unknown-wasip1" && !support_dynamic_linking?
       # wasi-vfs supports only WASI target
       wasi_vfs = RubyWasmExt::WasiVfs.new
       wasi_vfs.map_dir("/bundle", fs.bundle_dir)
@@ -72,7 +72,7 @@ class RubyWasm::Packager
   # Retrieves the build options used for building Ruby itself.
   def build_options
     default = {
-      target: RubyWasm::Target.new("wasm32-unknown-wasi"),
+      target: RubyWasm::Target.new("wasm32-unknown-wasip1"),
       default_exts: ALL_DEFAULT_EXTS
     }
     override = @config || {}

--- a/rakelib/ci.rake
+++ b/rakelib/ci.rake
@@ -86,7 +86,7 @@ def rake_task_matrix
         task: "standalone:#{pkg[:name]}",
         artifact: "packages/standalone/#{pkg[:name]}/dist",
         artifact_name: "standalone-#{pkg[:name]}",
-        builder: "wasm32-unknown-wasi",
+        builder: "wasm32-unknown-wasip1",
         rubies_cache_key: ruby_cache_keys[pkg[:build]]
       }
     end

--- a/rakelib/packaging.rake
+++ b/rakelib/packaging.rake
@@ -61,7 +61,7 @@ namespace :npm do
         end
         dist_dir = File.join(pkg_dir, "dist")
         mkdir_p dist_dir
-        if pkg[:target] == "wasm32-unknown-wasi"
+        if pkg[:target].start_with?("wasm32-unknown-wasi")
           Dir.chdir(cwd || base_dir) do
             sh env,
                *build_command,

--- a/ruby_wasm.gemspec
+++ b/ruby_wasm.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|
       (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor)}) ||
-        f.match(%r{\Apackages/})
+        f.match(%r{\A(?:packages|builders)/})
     end
   end
   spec.bindir = "exe"


### PR DESCRIPTION
WASI community is going to be introducing pN suffix to the target triples to distinguish the different versions of the WASI Preview versions (e.g. `wasm32-unknown-wasip1` for WASI Preview1) to prepare the upcoming WASI Preview2 and so on.

Other projects are also following this change:
* https://github.com/WebAssembly/wasi-libc/pull/478
* https://github.com/rust-lang/compiler-team/issues/607