### PR TITLE
FIX broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Dependencies: [wasmtime](https://github.com/bytecodealliance/wasmtime)
 ```console
 $ gem install ruby_wasm
 # Download a prebuilt Ruby release
-$ curl -LO https://github.com/ruby/ruby.wasm/releases/latest/download/ruby-3.3-wasm32-unknown-wasip1-full.tar.gz
+$ curl -LO https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0.tar.gz
 $ tar xfz ruby-3.3-wasm32-unknown-wasip1-full.tar.gz
 
 # Extract ruby binary not to pack itself


### PR DESCRIPTION
not sure if this is correct link.

however I am having issue extracting ruby binary not to pack itself:

```sh
mv ruby-3.3.0/usr/local/bin/ruby ruby.wasm
```
as there is no `/usr` directory
<img width="1602" alt="image" src="https://github.com/ruby/ruby.wasm/assets/70934030/67dfed13-7074-4efb-9efa-bc013e104ff3">

