### PR TITLE
Use upstream jco with TS binding generation support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/jco"]
 	path = vendor/jco
-	url = git@github.com:kateinoigakukun/jco.git
+	url = https://github.com/bytecodealliance/jco.git

--- a/package-lock.json
+++ b/package-lock.json
@@ -538,9 +538,9 @@
             "link": true
         },
         "node_modules/@bytecodealliance/preview2-shim": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.16.1.tgz",
-            "integrity": "sha512-KEzFY1/fSBF0cpUNbG9MdnPNc0gxinBm42HRA9+ENfsticSDjE845bh7Mun0UDD7ga/uWX061qZsfpBXUGEAfg==",
+            "version": "0.16.2",
+            "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.16.2.tgz",
+            "integrity": "sha512-36MwesmbLSf3Y5/OHcS85iBaF0N92CQ4gpjtDVKSbrjxmrBKCWlWVfoQ03F/cqDg8k5K7pzVaVBH0XBIbTCfTQ==",
             "dev": true
         },
         "node_modules/@bytecodealliance/wizer": {
@@ -8106,14 +8106,14 @@
         },
         "vendor/jco": {
             "name": "@bytecodealliance/jco",
-            "version": "1.1.1",
+            "version": "1.2.1",
             "dev": true,
             "license": "(Apache-2.0 WITH LLVM-exception)",
             "workspaces": [
                 "packages/preview2-shim"
             ],
             "dependencies": {
-                "@bytecodealliance/preview2-shim": "^0.16.1",
+                "@bytecodealliance/preview2-shim": "^0.16.2",
                 "binaryen": "^116.0.0",
                 "chalk-template": "^1",
                 "commander": "^12",
@@ -8536,7 +8536,7 @@
             "version": "file:vendor/jco",
             "requires": {
                 "@bytecodealliance/componentize-js": "^0.8.3",
-                "@bytecodealliance/preview2-shim": "^0.16.1",
+                "@bytecodealliance/preview2-shim": "^0.16.2",
                 "@types/node": "^18.11.17",
                 "@typescript-eslint/eslint-plugin": "^5.41.0",
                 "@typescript-eslint/parser": "^5.41.0",
@@ -8563,9 +8563,9 @@
             }
         },
         "@bytecodealliance/preview2-shim": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.16.1.tgz",
-            "integrity": "sha512-KEzFY1/fSBF0cpUNbG9MdnPNc0gxinBm42HRA9+ENfsticSDjE845bh7Mun0UDD7ga/uWX061qZsfpBXUGEAfg==",
+            "version": "0.16.2",
+            "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.16.2.tgz",
+            "integrity": "sha512-36MwesmbLSf3Y5/OHcS85iBaF0N92CQ4gpjtDVKSbrjxmrBKCWlWVfoQ03F/cqDg8k5K7pzVaVBH0XBIbTCfTQ==",
             "dev": true
         },
         "@bytecodealliance/wizer": {

--- a/packages/npm-packages/ruby-wasm-wasi/src/bindgen/interfaces/ruby-js-ruby-runtime.d.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/bindgen/interfaces/ruby-js-ruby-runtime.d.ts
@@ -23,8 +23,8 @@ export { JsAbiValue };
 export type RbErrno = number;
 export type RbId = number;
 
-export class RbIseq {
+export class RbAbiValue {
 }
 
-export class RbAbiValue {
+export class RbIseq {
 }

--- a/packages/npm-packages/ruby-wasm-wasi/tools/component-ts-bindgen.mjs
+++ b/packages/npm-packages/ruby-wasm-wasi/tools/component-ts-bindgen.mjs
@@ -3,7 +3,7 @@
  * in the js gem.
  */
 import { fileURLToPath } from "url";
-import { generateTypes, $init } from "../../../../node_modules/@bytecodealliance/jco/obj/js-component-bindgen-component.js";
+import { types } from "@bytecodealliance/jco";
 import path from "path"
 import fs from "fs/promises"
 
@@ -13,24 +13,21 @@ async function main() {
     selfPath,
     "../../../../gems/js/wit"
   ))
-  await $init
   console.log(`Generating TypeScript bindings from ${witDir}`)
-  const generated = generateTypes("ruby", {
-    wit: {
-      tag: "dir",
-      val: witDir
-    },
-    world: "ext",
-    tlaCompat: true
-  })
   const bindgenDir = path.join(selfPath, "../../src/bindgen")
-  for (const [name, content] of generated) {
+  const generated = await types(witDir, {
+    name: "ruby",
+    world: "ext",
+    tlaCompat: true,
+    outDir: bindgenDir,
+  })
+  for (const [filePath, content] of Object.entries(generated)) {
+    const name = path.basename(filePath)
     if (name == "ruby.d.ts") {
       console.log(`Skipping ${name}`)
       continue;
     }
 
-    const filePath = path.join(bindgenDir, name)
     console.log(`Writing ${filePath}`)
     await fs.mkdir(path.dirname(filePath), { recursive: true })
     await fs.writeFile(filePath, content)

--- a/packages/npm-packages/ruby-wasm-wasi/tools/pack-bindgen-src.sh
+++ b/packages/npm-packages/ruby-wasm-wasi/tools/pack-bindgen-src.sh
@@ -10,6 +10,6 @@ package_dir="$(cd "$(dirname "$0")/.." && pwd)"
 dist_dir="$1"
 
 for format in "esm" "cjs"; do
-  mkdir -p "$dist_dir/$format/bindgen"
-  find "$package_dir/src/bindgen" -name "*.d.ts" -exec cp {} "$dist_dir/$format/bindgen" \;
+  mkdir -p "$dist_dir/$format/bindgen/legacy"
+  find "$package_dir/src/bindgen/legacy" -name "*.d.ts" -exec cp {} "$dist_dir/$format/bindgen/legacy" \;
 done


### PR DESCRIPTION
Thanks to https://github.com/bytecodealliance/jco/pull/426, we can use the upstream jco without fork