### PR TITLE
Test against ruby verions 3.3 in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,13 +25,16 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     if: ${{ github.event_name == 'pull_request' }}
+    strategy:
+      matrix:
+        ruby-version: ['3.2', '3.3']
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: ./bin/setup
       - run: bundle exec rake check:type
@@ -73,11 +76,14 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       entries: ${{ steps.set-matrix.outputs.entries }}
+    strategy:
+      matrix:
+        ruby-version: ['3.2', '3.3']
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: ${{ matrix.ruby-version}}
           bundler-cache: true
       - run: ./bin/setup
       - run: rake ci:pin_build_manifest
@@ -98,7 +104,7 @@ jobs:
       fail-fast: false
       matrix:
         entry: ${{ fromJson(needs.build-rake-task-matrix.outputs.entries) }}
-
+        ruby-version: ['3.2', '3.3']
     needs: [build-rake-task-matrix]
     runs-on: ubuntu-20.04
     steps:
@@ -144,7 +150,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         if: ${{ matrix.entry.test != '' }}
         with:
-          ruby-version: "3.2"
+          ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: false
       - name: rake ${{ matrix.entry.test }}
         run: |
@@ -161,6 +167,9 @@ jobs:
     needs: [rake-tasks]
     runs-on: ubuntu-20.04
     if: ${{ startsWith(github.ref, 'refs/tags/') || inputs.publish }}
+    strategy:
+      matrix:
+          ruby-version: ['3.2', '3.3']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -175,7 +184,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
       - run: ./bin/setup
       - run: echo "PREREL_NAME=${{ inputs.prerel_name }}" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,16 +25,13 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     if: ${{ github.event_name == 'pull_request' }}
-    strategy:
-      matrix:
-        ruby-version: ['3.2', '3.3']
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: "3.3"
           bundler-cache: true
       - run: ./bin/setup
       - run: bundle exec rake check:type
@@ -76,14 +73,11 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       entries: ${{ steps.set-matrix.outputs.entries }}
-    strategy:
-      matrix:
-        ruby-version: ['3.2', '3.3']
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby-version}}
+          ruby-version: "3.3"
           bundler-cache: true
       - run: ./bin/setup
       - run: rake ci:pin_build_manifest
@@ -104,7 +98,6 @@ jobs:
       fail-fast: false
       matrix:
         entry: ${{ fromJson(needs.build-rake-task-matrix.outputs.entries) }}
-        ruby-version: ['3.2', '3.3']
     needs: [build-rake-task-matrix]
     runs-on: ubuntu-20.04
     steps:
@@ -150,7 +143,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         if: ${{ matrix.entry.test != '' }}
         with:
-          ruby-version: ${{ matrix.ruby-version }}
+          ruby-version: "3.3"
           bundler-cache: false
       - name: rake ${{ matrix.entry.test }}
         run: |
@@ -167,9 +160,6 @@ jobs:
     needs: [rake-tasks]
     runs-on: ubuntu-20.04
     if: ${{ startsWith(github.ref, 'refs/tags/') || inputs.publish }}
-    strategy:
-      matrix:
-          ruby-version: ['3.2', '3.3']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -184,7 +174,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby-version }}
+          ruby-version: "3.3"
           bundler-cache: true
       - run: ./bin/setup
       - run: echo "PREREL_NAME=${{ inputs.prerel_name }}" >> $GITHUB_ENV


### PR DESCRIPTION
I believe ruby.wasm supports ruby versions 3.2 and 3.3. Should we test against these versions?