### PR TITLE
Allow using `CXX` in extconf.rb

### DIFF
--- a/lib/ruby_wasm/build/product/crossruby.rb
+++ b/lib/ruby_wasm/build/product/crossruby.rb
@@ -34,6 +34,7 @@ module RubyWasm
     def make_args(crossruby)
       make_args = []
       make_args << "CC=#{@toolchain.cc}"
+      make_args << "CXX=#{@toolchain.cc}"
       make_args << "LD=#{@toolchain.ld}"
       make_args << "AR=#{@toolchain.ar}"
       make_args << "RANLIB=#{@toolchain.ranlib}"

--- a/lib/ruby_wasm/build/product/product.rb
+++ b/lib/ruby_wasm/build/product/product.rb
@@ -26,6 +26,7 @@ module RubyWasm
     def tools_args
       args = []
       args << "CC=#{@toolchain.cc}"
+      args << "CXX=#{@toolchain.cxx}"
       args << "LD=#{@toolchain.ld}"
       args << "AR=#{@toolchain.ar}"
       args << "RANLIB=#{@toolchain.ranlib}"

--- a/lib/ruby_wasm/build/toolchain.rb
+++ b/lib/ruby_wasm/build/toolchain.rb
@@ -43,7 +43,7 @@ module RubyWasm
       tool
     end
 
-    %i[cc ranlib ld ar].each do |name|
+    %i[cc cxx ranlib ld ar].each do |name|
       define_method(name) do
         @tools_cache ||= {}
         @tools_cache[name] ||= find_tool(name)
@@ -84,6 +84,7 @@ module RubyWasm
 
       @tools = {
         cc: "#{wasi_sdk_path}/bin/clang",
+        cxx: "#{wasi_sdk_path}/bin/clang++",
         ld: "#{wasi_sdk_path}/bin/clang",
         ar: "#{wasi_sdk_path}/bin/llvm-ar",
         ranlib: "#{wasi_sdk_path}/bin/llvm-ranlib"

--- a/sig/ruby_wasm/build.rbs
+++ b/sig/ruby_wasm/build.rbs
@@ -242,6 +242,7 @@ module RubyWasm
     def self.find_path: (String command) -> String?
     def self.check_executable: (String command) -> String
     def cc: -> String
+    def cxx: -> String
     def ranlib: -> String
     def ld: -> String
     def ar: -> String


### PR DESCRIPTION
Some extconf.rb scripts use CXX to compile C++ code even though CRuby itself doesn't require C++ compiler. This change allows such scripts to work correctly.