### PR TITLE
Fix missing Asyncify-loop on exposed entry points

### DIFF
--- a/packages/gems/js/ext/js/js-core.c
+++ b/packages/gems/js/ext/js/js-core.c
@@ -438,7 +438,7 @@ static VALUE _rb_js_import_from_js(VALUE obj) {
  *  Returns +obj+ wrapped by JS class RbValue.
  */
 static VALUE _rb_js_obj_wrap(VALUE obj, VALUE wrapping) {
-#if JS_ENABLE_COMPONENT_MODEL
+#ifdef JS_ENABLE_COMPONENT_MODEL
   rb_abi_stage_rb_value_to_js(wrapping);
   return jsvalue_s_new(rb_js_abi_host_rb_object_to_js_rb_value());
 #else
@@ -511,7 +511,7 @@ static VALUE _rb_js_false_to_js(VALUE obj) {
  *  Returns +self+ as a JS::Object.
  */
 static VALUE _rb_js_proc_to_js(VALUE obj) {
-#if JS_ENABLE_COMPONENT_MODEL
+#ifdef JS_ENABLE_COMPONENT_MODEL
   rb_abi_stage_rb_value_to_js(obj);
   return jsvalue_s_new(ruby_js_js_runtime_proc_to_js_function());
 #else

--- a/packages/gems/js/ext/js/witapi-core.c
+++ b/packages/gems/js/ext/js/witapi-core.c
@@ -358,6 +358,8 @@ bool rb_abi_guest_rb_set_should_prohibit_rewind(bool value) {
   return old;
 }
 
+#ifdef JS_ENABLE_COMPONENT_MODEL
+
 static VALUE rb_abi_export_stage = Qnil;
 static rb_abi_guest_own_rb_abi_value_t rb_abi_export_rb_value_to_js(void) {
   VALUE staged = rb_abi_export_stage;
@@ -371,8 +373,6 @@ void rb_abi_stage_rb_value_to_js(VALUE value) {
          "rb_abi_stage_rb_value_to_js: stage is not empty!?");
   rb_abi_export_stage = value;
 }
-
-#ifdef JS_ENABLE_COMPONENT_MODEL
 
 extern void __wasm_call_ctors(void);
 static inline void __wasm_call_ctors_if_needed(void) {


### PR DESCRIPTION
Some of operations that *may* trigger Asyncify-unwind were not surrounded by the Asyncify-loop. Without the loop, the unwinding would not be stopped at the boundary of the guest function, and the continuation would be lost. Typically, unwinding for scanning GC root from Wasm locals were not rewound properly, then the GC would miss some objects and cause a crash.