### PR TITLE
Add wasi_shim as dependency

### DIFF
--- a/packages/npm-packages/ruby-wasm-wasi/package.json
+++ b/packages/npm-packages/ruby-wasm-wasi/package.json
@@ -54,7 +54,6 @@
     "build": "npm run build:rollup && npm run build:tsc && npm run build:static && ./tools/post-build.sh ./dist"
   },
   "devDependencies": {
-    "@bjorn3/browser_wasi_shim": "^0.3.0",
     "@bytecodealliance/jco": "../../../vendor/jco",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-typescript": "^11.1.6",
@@ -64,6 +63,7 @@
     "vitest": "^1.6.0"
   },
   "dependencies": {
+    "@bjorn3/browser_wasi_shim": "^0.3.0",
     "tslib": "^2.6.3"
   }
 }


### PR DESCRIPTION
If it is in devDependency, then esm.sh and other CDN fails to resolve the dependency.
Please consider moving the shim to dependency from devDependency.