### PR TITLE
Add a base_url property to JS::RequreRemote to specify the base URL for resolving relative paths.

### DIFF
--- a/packages/gems/js/lib/js/require_remote.rb
+++ b/packages/gems/js/lib/js/require_remote.rb
@@ -49,8 +49,6 @@ module JS
       @evaluator = Evaluator.new
     end
 
-    # Initialize the instance.
-    #
     # If you want to resolve relative paths to a starting point other than the HTML file that executes ruby.wasm,
     # you can set the base_url property.
     # For example, if you want to use the `lib` directory as the starting point, specify base_url as follows

--- a/packages/gems/js/lib/js/require_remote.rb
+++ b/packages/gems/js/lib/js/require_remote.rb
@@ -43,9 +43,27 @@ module JS
     include Singleton
 
     def initialize
+      # By default, the base_url is the URL of the HTML file that invoked ruby.wasm vm.
       base_url = JS.global[:URL].new(JS.global[:location][:href])
       @resolver = URLResolver.new(base_url)
       @evaluator = Evaluator.new
+    end
+
+    # Initialize the instance.
+    #
+    # If you want to resolve relative paths to a starting point other than the HTML file that executes ruby.wasm,
+    # you can set the base_url property.
+    # For example, if you want to use the `lib` directory as the starting point, specify base_url as follows
+    #
+    # == Example
+    #  require 'js/require_remote'
+    #  JS::RequireRemote.instance.base_url = "lib"
+    #  JS::RequireRemote.instance.load("foo") # => 'lib/foo.rb' will be loaded.
+    #
+    def base_url=(base_url)
+      base_url = base_url.end_with?("/") ? base_url : "#{base_url}/"
+      url = JS.global[:URL].new(base_url, JS.global[:location][:href])
+      @resolver = URLResolver.new(url)
     end
 
     # Load the given feature from remote.

--- a/packages/gems/js/lib/js/require_remote/url_resolver.rb
+++ b/packages/gems/js/lib/js/require_remote/url_resolver.rb
@@ -26,6 +26,10 @@ module JS
         @url_stack.pop
       end
 
+      def inspect
+        "#{self.class}(#{@url_stack})"
+      end
+
       private
 
       def filename_from(relative_feature)

--- a/packages/npm-packages/ruby-wasm-wasi/test-e2e/integrations/js-require-remote.spec.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/test-e2e/integrations/js-require-remote.spec.ts
@@ -115,5 +115,24 @@ if (!process.env.RUBY_NPM_PACKAGE_ROOT) {
 
       expect(await resolve()).toBe("Hello from RecursiveRequire::B");
     });
+
+    test("JS::RequireRemote#load loads a file with a relative path from base_url option", async ({
+      page
+    }) => {
+      const resolve = await resolveBinding(page, "checkResolved");
+      await page.goto(
+        "https://cdn.jsdelivr.net/npm/@ruby/head-wasm-wasi@latest/dist/",
+      );
+      await page.setContent(`
+      <script src="browser.script.iife.js"></script>
+      <script type="text/ruby" data-eval="async">
+        require 'js/require_remote'
+        JS::RequireRemote.instance.base_url = 'fixtures'
+        JS.global.checkResolved JS::RequireRemote.instance.load 'error_on_load_twice'
+      </script>
+     `);
+
+      expect(await resolve()).toBe(true);
+    });
   });
 }

--- a/packages/npm-packages/ruby-wasm-wasi/test-e2e/integrations/js-require-remote.spec.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/test-e2e/integrations/js-require-remote.spec.ts
@@ -117,7 +117,7 @@ if (!process.env.RUBY_NPM_PACKAGE_ROOT) {
     });
 
     test("JS::RequireRemote#load loads the file with a path relative to the base_url specified by the base_url property.", async ({
-      page
+      page,
     }) => {
       const resolve = await resolveBinding(page, "checkResolved");
       await page.goto(

--- a/packages/npm-packages/ruby-wasm-wasi/test-e2e/integrations/js-require-remote.spec.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/test-e2e/integrations/js-require-remote.spec.ts
@@ -116,7 +116,7 @@ if (!process.env.RUBY_NPM_PACKAGE_ROOT) {
       expect(await resolve()).toBe("Hello from RecursiveRequire::B");
     });
 
-    test("JS::RequireRemote#load loads a file with a relative path from base_url option", async ({
+    test("JS::RequireRemote#load loads the file with a path relative to the base_url specified by the base_url property.", async ({
       page
     }) => {
       const resolve = await resolveBinding(page, "checkResolved");
@@ -127,12 +127,13 @@ if (!process.env.RUBY_NPM_PACKAGE_ROOT) {
       <script src="browser.script.iife.js"></script>
       <script type="text/ruby" data-eval="async">
         require 'js/require_remote'
-        JS::RequireRemote.instance.base_url = 'fixtures'
-        JS.global.checkResolved JS::RequireRemote.instance.load 'error_on_load_twice'
+        JS::RequireRemote.instance.base_url = 'fixtures/recursive_require'
+        JS::RequireRemote.instance.load 'b'
+        JS.global.checkResolved RecursiveRequire::B.new.message
       </script>
      `);
 
-      expect(await resolve()).toBe(true);
+      expect(await resolve()).toBe("Hello from RecursiveRequire::B");
     });
   });
 }


### PR DESCRIPTION
## Before

Currently, `JS::RequireRemote` treats the URL of the HTML file that calls ruby.wasm as the base URL for resolving relative paths. For this reason, you will have to write an uncomfortable require_relative if you place the Ruby script that serves as the entry point in a directory different from the HTML file.


For example, if the entry point for a Ruby script is placed in the `lib` directory as follows:

```html
<script type="text/ruby" src="lib/init.rb" data-eval="async"></script>
```

If you want to read the `jsrb.rb` file in the same `lib` directory, include the `lib` directory in the `require_relative` argument, like `require_relative 'lib/jsrb'`. Or, specify an absolute path, such as `/lib/jsrb`.


```ruby
require 'js/require_remote'
module Kernel
  def require_relative(path)
    JS::RequireRemote.instance.load(path)
  end
end

require_relative '/lib/jsrb'
```

## After

If you set `lib` in the base_url property as follows, you can write `require_relative 'jsrb'` as a relative path from `lib/init.rb`.

```ruby
require 'js/require_remote'

JS::RequireRemote.instance.base_url = "lib" # Set base_url

module Kernel
  def require_relative(path)
    JS::RequireRemote.instance.load(path)
  end
end

require_relative 'jsrb' # We can specify relative_path for jsrb.rb
```

## Why not automatically resolve the base URL?

I do not know if `JS::RequireRemote` is used when a ruby script is loaded with the script tag. It is not appropriate to change the `JS::RequireRemote` setting at this time.

Also, when multiple ruby scripts are loaded in a script tag, I am not sure which ruby script path should be used as the base URL.