### PR TITLE
Undefine Object#send method to call JavaScript send method

### DIFF
--- a/packages/gems/js/lib/js.rb
+++ b/packages/gems/js/lib/js.rb
@@ -195,6 +195,16 @@ class JS::Object
     self[sym].typeof == "function"
   end
 
+  # To call the JavaScript `send` method and to check whether the `send` method exists, delete the definition of `Object#send`.
+  #
+  # For example, the JavaScript `WebSocket` and `XMLHttpRequest` have a `send` method.
+  # The JavaScript method call short-hand in JS::Object is implemented using method_missing.
+  # Therefore, if `Object#send` is defined, `Object#send` will be given priority over the JavaScript `send` method.
+  # The same applies to the `respond_to_missing?` method.
+  #
+  # Please use `BasicObject#__send__` instead.
+  undef_method :send
+
   # Call the receiver (a JavaScript function) with `undefined` as its receiver context. 
   # This method is similar to JS::Object#call, but it is used to call a function that is not
   # a method of an object.

--- a/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
+++ b/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
@@ -290,6 +290,13 @@ class JS::TestObject < Test::Unit::TestCase
     assert_equal "o", JS.eval("return 'hello';").charAt(4).to_s
   end
 
+  def test_method_missing_for_send_method
+    object = JS.eval(<<~JS)
+      return { send(message) { return message; } };
+    JS
+    assert_equal "hello", object.send('hello').to_s
+  end
+
   def test_method_missing_with_block
     obj = JS.eval(<<~JS)
       return {
@@ -351,6 +358,7 @@ class JS::TestObject < Test::Unit::TestCase
     assert_true object.respond_to?(:foo)
     assert_true object.respond_to?(:new)
     assert_false object.respond_to?(:bar)
+    assert_false object.respond_to?(:send)
   end
 
   def test_member_get

--- a/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
+++ b/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
@@ -290,13 +290,6 @@ class JS::TestObject < Test::Unit::TestCase
     assert_equal "o", JS.eval("return 'hello';").charAt(4).to_s
   end
 
-  def test_method_missing_for_send_method
-    object = JS.eval(<<~JS)
-      return { send(message) { return message; } };
-    JS
-    assert_equal "hello", object.send('hello').to_s
-  end
-
   def test_method_missing_with_block
     obj = JS.eval(<<~JS)
       return {
@@ -358,7 +351,20 @@ class JS::TestObject < Test::Unit::TestCase
     assert_true object.respond_to?(:foo)
     assert_true object.respond_to?(:new)
     assert_false object.respond_to?(:bar)
-    assert_false object.respond_to?(:send)
+  end
+
+  def test_send_method_for_javascript_object_with_send_method
+    object = JS.eval(<<~JS)
+      return { send(message) { return message; } };
+    JS
+    assert_equal "hello", object.send('hello').to_s
+  end
+
+  def test_send_method_for_javascript_object_without_send_method
+    object = JS.eval(<<~JS)
+      return { write(message) { return message; } };
+    JS
+    assert_equal "hello", object.send(:write, 'hello').to_s
   end
 
   def test_member_get


### PR DESCRIPTION
## Background

The following ruby.wasm code will cause an error.

```ruby
ws = JS.global[:WebSocket].new("ws://localhost:9292")
ws[:onopen] = -> (event) {
  ws.send("Hello")
}
```

```
Error: /bundle/gems/js-2.6.2/lib/js.rb:184:in `method_missing': undefined method `Hello' for an instance of JS::Object (NoMethodError)
```

This error is caused by the `Object#send` method being called instead of the `send` method of the JavaScript WebSocket object.

Currently, we can use the send method by using the call method as follows.

```rb
ws.call(:send, ["Hello"])
```


## Goal


Enable to call the JavaScript `send` method with the following syntax:
  
```ruby
ws.send("Hello, world! from Ruby")
```

## Solution

### 1st approch

Undef `Object#send` method.
But, this is too much change to enable short-hand methods.

### 2nd approch

Overirde `Object#send` method.
Then, it checks whether the JavaScript object has a `send` method and changes its behavior.


