### PR TITLE
Fix `403 Forbidden` in `Build ruby.wasm` Github Actions Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
         id: meta
         with:
           images: ghcr.io/${{ github.repository_owner }}/ruby.wasm/builder/${{ matrix.entry.target }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: builders/${{ matrix.entry.target }}
           push: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/tags/*' }}
@@ -113,7 +113,7 @@ jobs:
           path: ./rubies
           key: ${{ matrix.entry.rubies_cache_key }}
       - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         id: builder-image
         env:
           DOCKER_BUILD_NO_SUMMARY: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,9 @@ jobs:
       - run: git diff --exit-code
 
   build-builder-image:
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fixes #513 by:
- upgrading `docker/build-push-action` from v5 to v6
- adding required permissions to the `build-builder-image` step