### PR TITLE
Prevents errors that occur when calling a non-existent JavaScript property with a question mark

### DIFF
--- a/packages/gems/js/lib/js.rb
+++ b/packages/gems/js/lib/js.rb
@@ -173,11 +173,15 @@ class JS::Object
     if sym_str.end_with?("?")
       # When a JS method is called with a ? suffix, it is treated as a predicate method,
       # and the return value is converted to a Ruby boolean value automatically.
-      result = self.call(sym_str[0..-2].to_sym, *args, &block)
-
-      # Type coerce the result to boolean type
-      # to match the true/false determination in JavaScript's if statement.
-      JS.global.Boolean(result) == JS::True
+      sym = sym_str[0..-2].to_sym
+      if self[sym].typeof == "function"
+        result = self.call(sym, *args, &block)
+        # Type coerce the result to boolean type
+        # to match the true/false determination in JavaScript's if statement.
+        JS.global.Boolean(result) == JS::True
+      else
+        false
+      end
     elsif self[sym].typeof == "function"
       self.call(sym, *args, &block)
     else

--- a/packages/gems/js/lib/js.rb
+++ b/packages/gems/js/lib/js.rb
@@ -173,20 +173,13 @@ class JS::Object
     if sym_str.end_with?("?")
       # When a JS method is called with a ? suffix, it is treated as a predicate method,
       # and the return value is converted to a Ruby boolean value automatically.
-      sym = sym_str[0..-2].to_sym
-      if self[sym].typeof == "function"
-        result = self.call(sym, *args, &block)
-        # Type coerce the result to boolean type
-        # to match the true/false determination in JavaScript's if statement.
-        return JS.global.Boolean(result) == JS::True
-      end
+      result = invoke_js_method(sym_str[0..-2].to_sym, *args, &block)
+      # Type coerce the result to boolean type
+      # to match the true/false determination in JavaScript's if statement.
+      return JS.global.Boolean(result) == JS::True
     end
 
-    if self[sym].typeof == "function"
-      return self.call(sym, *args, &block)
-    end
-
-    super
+    invoke_js_method(sym, *args, &block)
   end
 
   # Check if a JavaScript method exists
@@ -242,6 +235,24 @@ class JS::Object
     # Promise.resolve wrap a value or flattens promise-like object and its thenable chain
     promise = JS.global[:Promise].resolve(self)
     JS.promise_scheduler.await(promise)
+  end
+
+  private
+
+  # Invoke a JavaScript method
+  # If the property of JavaScritp object does not exist, raise a `NoMethodError`.
+  # If the property exists but is not a function, raise a `TypeError`.
+  def invoke_js_method(sym, *args, &block)
+    return self.call(sym, *args, &block) if self[sym].typeof == "function"
+
+    # Check to see if a non-functional property exists.
+    if JS.global[:Reflect].call(:has, self, sym.to_s) == JS::True
+      raise TypeError,
+            "`#{sym}` is not a function. To reference a property, use `[:#{sym}]` syntax instead."
+    end
+
+    raise NoMethodError,
+          "undefined method `#{sym}' for an instance of JS::Object"
   end
 end
 

--- a/packages/gems/js/lib/js.rb
+++ b/packages/gems/js/lib/js.rb
@@ -195,10 +195,10 @@ class JS::Object
     self[sym].typeof == "function"
   end
 
-  # Call the receiver (a JavaScript function) with `undefined` as its receiver context. 
+  # Call the receiver (a JavaScript function) with `undefined` as its receiver context.
   # This method is similar to JS::Object#call, but it is used to call a function that is not
   # a method of an object.
-  #   
+  #
   #   floor = JS.global[:Math][:floor]
   #   floor.apply(3.14) # => 3
   #   JS.global[:Promise].new do |resolve, reject|

--- a/packages/gems/js/lib/js.rb
+++ b/packages/gems/js/lib/js.rb
@@ -178,15 +178,15 @@ class JS::Object
         result = self.call(sym, *args, &block)
         # Type coerce the result to boolean type
         # to match the true/false determination in JavaScript's if statement.
-        JS.global.Boolean(result) == JS::True
-      else
-        false
+        return JS.global.Boolean(result) == JS::True
       end
-    elsif self[sym].typeof == "function"
-      self.call(sym, *args, &block)
-    else
-      super
     end
+
+    if self[sym].typeof == "function"
+      return self.call(sym, *args, &block)
+    end
+
+    super
   end
 
   # Check if a JavaScript method exists

--- a/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
+++ b/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
@@ -310,13 +310,6 @@ class JS::TestObject < Test::Unit::TestCase
     assert_true block_called
   end
 
-  def test_method_missing_with_undefined_method
-    object = JS.eval(<<~JS)
-      return { foo() { return true; } };
-    JS
-    assert_raise(NoMethodError) { object.bar }
-  end
-
   def test_method_missing_with_?
     object = JS.eval(<<~JS)
       return {
@@ -324,8 +317,7 @@ class JS::TestObject < Test::Unit::TestCase
         return_false() { return false; },
         return_object() { return {}; },
         return_null() { return null; },
-        return_empty_string() { return ''; },
-        true_property: true
+        return_empty_string() { return ''; }
       };
     JS
 
@@ -343,12 +335,22 @@ class JS::TestObject < Test::Unit::TestCase
     # Return Ruby false when the return value is JavaScript false
     assert_false object.return_null?
     assert_false object.return_empty_string?
+  end
 
-    # Return false when the property is not a function
-    assert_false object.true_property?
+  def test_method_missing_with_property
+    object = JS.eval(<<~JS)
+      return { property: 42 };
+    JS
+    assert_raise(NoMethodError) { object.property }
+    assert_raise(NoMethodError) { object.property? }
+  end
 
-    # Return false when function is not defined
-    assert_false object.undefined?
+  def test_method_missing_with_undefined_method
+    object = JS.eval(<<~JS)
+      return { foo() { return true; } };
+    JS
+    assert_raise(NoMethodError) { object.bar }
+    assert_raise(NoMethodError) { object.bar? }
   end
 
   def test_respond_to_missing?

--- a/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
+++ b/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
@@ -324,7 +324,8 @@ class JS::TestObject < Test::Unit::TestCase
         return_false() { return false; },
         return_object() { return {}; },
         return_null() { return null; },
-        return_empty_string() { return ''; }
+        return_empty_string() { return ''; },
+        return_number: 42
       };
     JS
 
@@ -342,6 +343,12 @@ class JS::TestObject < Test::Unit::TestCase
     # Return Ruby false when the return value is JavaScript false
     assert_false object.return_null?
     assert_false object.return_empty_string?
+
+    # Return false when the property is not a function
+    assert_false object.return_number?
+
+    # Return false when function is not defined
+    assert_false object.undefined?
   end
 
   def test_respond_to_missing?

--- a/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
+++ b/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
@@ -325,7 +325,7 @@ class JS::TestObject < Test::Unit::TestCase
         return_object() { return {}; },
         return_null() { return null; },
         return_empty_string() { return ''; },
-        return_number: 42
+        true_property: true
       };
     JS
 
@@ -345,7 +345,7 @@ class JS::TestObject < Test::Unit::TestCase
     assert_false object.return_empty_string?
 
     # Return false when the property is not a function
-    assert_false object.return_number?
+    assert_false object.true_property?
 
     # Return false when function is not defined
     assert_false object.undefined?

--- a/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
+++ b/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
@@ -341,16 +341,27 @@ class JS::TestObject < Test::Unit::TestCase
     object = JS.eval(<<~JS)
       return { property: 42 };
     JS
-    assert_raise(NoMethodError) { object.property }
-    assert_raise(NoMethodError) { object.property? }
+
+    e = assert_raise(TypeError) { object.property }
+    assert_equal "`property` is not a function. To reference a property, use `[:property]` syntax instead.",
+                 e.message
+
+    e = assert_raise(TypeError) { object.property? }
+    assert_equal "`property` is not a function. To reference a property, use `[:property]` syntax instead.",
+                 e.message
   end
 
   def test_method_missing_with_undefined_method
     object = JS.eval(<<~JS)
       return { foo() { return true; } };
     JS
-    assert_raise(NoMethodError) { object.bar }
-    assert_raise(NoMethodError) { object.bar? }
+    e = assert_raise(NoMethodError) { object.bar }
+    assert_equal "undefined method `bar' for an instance of JS::Object",
+                 e.message
+
+    e = assert_raise(NoMethodError) { object.bar? }
+    assert_equal "undefined method `bar' for an instance of JS::Object",
+                 e.message
   end
 
   def test_respond_to_missing?


### PR DESCRIPTION
## Problem

```ruby
require 'js'
JS.global[:document].undefinded_method?
```

This code will cause the following error.


```
RbError: /bundle/gems/js-2.6.2.dev/lib/js.rb:176:in 'JS::Object#call': TypeError: Cannot read properties of undefined (reading 'undefinded_method')
```

This is because the JavaScript function existence check is missing.


## Solution

Checks for the existence of JavaScript functions.