### PR TITLE
Use the parse.y as a parser to avoid runtime errors.

### DIFF
--- a/packages/npm-packages/ruby-wasm-wasi/src/vm.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/vm.ts
@@ -323,7 +323,7 @@ export class RubyVM {
    * an array of strings starting with the Ruby program name.
    * @category Low-level initialization
    */
-  initialize(args: string[] = ["ruby.wasm", "-EUTF-8", "-e_=0"]) {
+  initialize(args: string[] = ["ruby.wasm", "-EUTF-8", "-e_=0", "--parser=parse.y"]) {
     const c_args = args.map((arg) => arg + "\0");
     this.guest.rubyInit(c_args);
     try {


### PR DESCRIPTION
 If you use the Prism as parser, you will get `RangeError: Maximum call stack size exceeded`.

I don't think changing the parser used in ruby.wasm from CRuby's default parser is the best way to go.
I think some kind of report to the Prism would be a good idea.
Before I do so, I have created a pull request to share what is happening.