### PR TITLE
Improve errer mesage for property

### DIFF
--- a/packages/gems/js/lib/js.rb
+++ b/packages/gems/js/lib/js.rb
@@ -173,16 +173,13 @@ class JS::Object
     if sym_str.end_with?("?")
       # When a JS method is called with a ? suffix, it is treated as a predicate method,
       # and the return value is converted to a Ruby boolean value automatically.
-      result = self.call(sym_str[0..-2].to_sym, *args, &block)
-
+      result = invoke_js_method(sym_str[0..-2].to_sym, *args, &block)
       # Type coerce the result to boolean type
       # to match the true/false determination in JavaScript's if statement.
-      JS.global.Boolean(result) == JS::True
-    elsif self[sym].typeof == "function"
-      self.call(sym, *args, &block)
-    else
-      super
+      return JS.global.Boolean(result) == JS::True
     end
+
+    invoke_js_method(sym, *args, &block)
   end
 
   # Check if a JavaScript method exists
@@ -238,6 +235,24 @@ class JS::Object
     # Promise.resolve wrap a value or flattens promise-like object and its thenable chain
     promise = JS.global[:Promise].resolve(self)
     JS.promise_scheduler.await(promise)
+  end
+
+  private
+
+  # Invoke a JavaScript method
+  # If the property of JavaScritp object does not exist, raise a `NoMethodError`.
+  # If the property exists but is not a function, raise a `TypeError`.
+  def invoke_js_method(sym, *args, &block)
+    return self.call(sym, *args, &block) if self[sym].typeof == "function"
+
+    # Check to see if a non-functional property exists.
+    if JS.global[:Reflect].call(:has, self, sym.to_s) == JS::True
+      raise TypeError,
+            "`#{sym}` is not a function. To reference a property, use `[:#{sym}]` syntax instead."
+    end
+
+    raise NoMethodError,
+          "undefined method `#{sym}' for an instance of JS::Object"
   end
 end
 

--- a/packages/gems/js/lib/js.rb
+++ b/packages/gems/js/lib/js.rb
@@ -195,10 +195,10 @@ class JS::Object
     self[sym].typeof == "function"
   end
 
-  # Call the receiver (a JavaScript function) with `undefined` as its receiver context. 
+  # Call the receiver (a JavaScript function) with `undefined` as its receiver context.
   # This method is similar to JS::Object#call, but it is used to call a function that is not
   # a method of an object.
-  #   
+  #
   #   floor = JS.global[:Math][:floor]
   #   floor.apply(3.14) # => 3
   #   JS.global[:Promise].new do |resolve, reject|

--- a/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
+++ b/packages/npm-packages/ruby-wasm-wasi/test/unit/test_object.rb
@@ -310,13 +310,6 @@ class JS::TestObject < Test::Unit::TestCase
     assert_true block_called
   end
 
-  def test_method_missing_with_undefined_method
-    object = JS.eval(<<~JS)
-      return { foo() { return true; } };
-    JS
-    assert_raise(NoMethodError) { object.bar }
-  end
-
   def test_method_missing_with_?
     object = JS.eval(<<~JS)
       return {
@@ -342,6 +335,33 @@ class JS::TestObject < Test::Unit::TestCase
     # Return Ruby false when the return value is JavaScript false
     assert_false object.return_null?
     assert_false object.return_empty_string?
+  end
+
+  def test_method_missing_with_property
+    object = JS.eval(<<~JS)
+      return { property: 42 };
+    JS
+
+    e = assert_raise(TypeError) { object.property }
+    assert_equal "`property` is not a function. To reference a property, use `[:property]` syntax instead.",
+                 e.message
+
+    e = assert_raise(TypeError) { object.property? }
+    assert_equal "`property` is not a function. To reference a property, use `[:property]` syntax instead.",
+                 e.message
+  end
+
+  def test_method_missing_with_undefined_method
+    object = JS.eval(<<~JS)
+      return { foo() { return true; } };
+    JS
+    e = assert_raise(NoMethodError) { object.bar }
+    assert_equal "undefined method `bar' for an instance of JS::Object",
+                 e.message
+
+    e = assert_raise(NoMethodError) { object.bar? }
+    assert_equal "undefined method `bar' for an instance of JS::Object",
+                 e.message
   end
 
   def test_respond_to_missing?


### PR DESCRIPTION
This work was originally done in #527.
After trying, I thought it would be a good idea to improve the message when a property of a JavaScript object is called as a method.

I hope this will help users quickly realize that they can't call a property as a method and their surprise will be tiny.