### PR TITLE
Remove a patch of the test-unit gem.

### DIFF
--- a/packages/npm-packages/ruby-wasm-wasi/test/unit/test_error.rb
+++ b/packages/npm-packages/ruby-wasm-wasi/test/unit/test_error.rb
@@ -2,8 +2,6 @@ require "test-unit"
 require "js"
 
 class JS::TestError < Test::Unit::TestCase
-  using JsObjectTestable
-
   def test_throw_error
     e = assert_raise(JS::Error) { JS.eval("throw new Error('foo')") }
     assert_match /^Error: foo/, e.message

--- a/packages/npm-packages/ruby-wasm-wasi/test/unit/test_float.rb
+++ b/packages/npm-packages/ruby-wasm-wasi/test/unit/test_float.rb
@@ -2,8 +2,6 @@ require "test-unit"
 require "js"
 
 class JS::TestFloat < Test::Unit::TestCase
-  using JsObjectTestable
-
   def test_to_js
     assert_equal (1.0).to_js, JS.eval("return 1.0;")
     assert_equal (0.5).to_js, JS.eval("return 0.5;")

--- a/packages/npm-packages/ruby-wasm-wasi/tools/run-test-unit.mjs
+++ b/packages/npm-packages/ruby-wasm-wasi/tools/run-test-unit.mjs
@@ -166,21 +166,8 @@ const test = async (instantiate) => {
   const rootTestFile = "/__root__/test/test_unit.rb";
   const { vm } = await instantiate(rootTestFile);
 
-
   await vm.evalAsync(`
     require 'test/unit'
-
-    # FIXME: This is a workaround for the test-unit gem.
-    # It will be removed when the next pull request is merged and released.
-    # https://github.com/test-unit/test-unit/pull/262
-    require 'pp'
-    module JsObjectTestable
-      refine JS::Object do
-        [:object_id, :pretty_inspect].each do |method|
-          define_method(method, ::Object.instance_method(method))
-        end
-      end
-    end
 
     require_relative '${rootTestFile}'
     ok = Test::Unit::AutoRunner.run


### PR DESCRIPTION
The following pull request has been made to the test-unit gem itself, which will make this patch unnecessary. 
https://github.com/test-unit/test-unit/pull/262

The above test-unit gem fix has already been released in the next release.
https://github.com/test-unit/test-unit/releases/tag/3.6.3