### PR TITLE
Set `$have_devel = true` for static build

### DIFF
--- a/lib/ruby_wasm/build/product/crossruby.rb
+++ b/lib/ruby_wasm/build/product/crossruby.rb
@@ -90,10 +90,15 @@ module RubyWasm
         "--disable=gems",
         # HACK: top_srcdir is required to find ruby headers
         "-e",
-        %Q($top_srcdir="#{source.src_dir}"),
+        %Q($top_srcdir=ENV["top_srcdir"]="#{source.src_dir}"),
         # HACK: extout is required to find config.h
         "-e",
-        %Q($extout="#{crossruby.build_dir}/.ext"),
+        %Q($extout=ENV["extout"]="#{crossruby.build_dir}/.ext"),
+        *(@features.support_component_model? ? [] : [
+          # HACK: skip have_devel check since ruby is not installed yet
+          "-e",
+          "$have_devel = true",
+        ]),
         # HACK: force static ext build by imitating extmk
         "-e",
         "$static = true; trace_var(:$static) {|v| $static = true }",


### PR DESCRIPTION
Previously, mkmf failed with --disable-component-model build, because it attempted to link during have_devel check but ruby is not installed yet.

This change reverts 70068a6140534f693eb895a4cb2c0b88769dd3fd partially. Setting `$have_devel = true` skips have_devel check.