### PR TITLE
Use Ruby 3.4.1 in CI instead of master

### DIFF
--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -33,20 +33,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
-          bundler-cache: true
-          cargo-cache: true
-          cargo-vendor: true
-          cache-version: v2-${{ matrix.ruby-platform }}
+          ruby-version: "3.4"
 
-      - name: Set vars
-        id: vars
-        run: |
-          echo "rb-sys-version=$(bundle exec ruby -rrb_sys -e 'puts RbSys::VERSION')" >> $GITHUB_OUTPUT
-      - uses: oxidize-rb/cross-gem-action@main
+      - uses: oxidize-rb/actions/cross-gem@v1
+        id: cross-gem
         with:
-          version: ${{ steps.vars.outputs.rb-sys-version }}
           platform: ${{ matrix.ruby-platform }}
-          ruby-versions: ${{ join(fromJSON(needs.ci-data.outputs.result).stable-ruby-versions, ', ') }}
+          ruby-versions: ${{ join(fromJSON(needs.ci-data.outputs.result).stable-ruby-versions, ',') }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cross-gem-${{ matrix.ruby-platform }}
+          path: ${{ steps.cross-gem.outputs.gem-path }}
+          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "head"
+          ruby-version: "3.4.1"
           bundler-cache: true
       - run: ./bin/setup
       - run: bundle exec rake check:type
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "head"
+          ruby-version: "3.4.1"
           bundler-cache: true
       - run: ./bin/setup
       - run: rake ci:pin_build_manifest
@@ -150,7 +150,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         if: ${{ matrix.entry.test != '' }}
         with:
-          ruby-version: "head"
+          ruby-version: "3.4.1"
           bundler-cache: false
       - name: rake ${{ matrix.entry.test }}
         run: |
@@ -176,7 +176,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "head"
+          ruby-version: "3.4.1"
           bundler-cache: true
       - run: ./bin/setup
       - run: echo "PREREL_NAME=${{ inputs.prerel_name }}" >> $GITHUB_ENV

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,18 +1269,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.97"
+version = "0.9.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d30bcad206b51f2f66121190ca678dce1fdf3a2eae0ac5d838d1818b19bdf5"
+checksum = "1e955384e1a4dc64b71d1e4b39ed0edbd77c7bde4a10dfd5ad208e1160fddfa7"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.97"
+version = "0.9.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbd92f281615f3c2dcb9dcb0f0576624752afbf9a7f99173b37c4b55b62dd8a"
+checksum = "c167c6571889b2550d6fcb315e8aa60bdb95e47e4b64793e3f65a30dc25afc85"
 dependencies = [
  "bindgen",
  "lazy_static",

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 group :development do
   gem "rake"
   gem "rake-compiler"
-  gem "rb_sys", "0.9.97"
+  gem "rb_sys", "0.9.108"
 end
 
 group :check do

--- a/builders/wasm32-unknown-wasip2/Dockerfile
+++ b/builders/wasm32-unknown-wasip2/Dockerfile
@@ -35,10 +35,12 @@ RUN set -eux pipefail; \
   chmod -R a+w $RUSTUP_HOME $CARGO_HOME
 
 # Install the latest Ruby to use the latest Bundler for cross-building C extension gems.
-ADD --keep-git-dir=true https://github.com/ruby/ruby.git /buildruby
+ADD https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.1.tar.gz /buildruby.tar.gz
 RUN set -eux; \
+  mkdir /buildruby; \
+  tar -xf /buildruby.tar.gz -C /buildruby --strip-components=1; \
+  rm /buildruby.tar.gz; \
   cd /buildruby; \
-  ./autogen.sh; \
   mkdir -p /opt/ruby; \
   ./configure --prefix=/opt/ruby --disable-install-doc; \
   make -j$(nproc); \

--- a/lib/ruby_wasm/build/product/crossruby.rb
+++ b/lib/ruby_wasm/build/product/crossruby.rb
@@ -94,11 +94,15 @@ module RubyWasm
         # HACK: extout is required to find config.h
         "-e",
         %Q($extout=ENV["extout"]="#{crossruby.build_dir}/.ext"),
-        *(@features.support_component_model? ? [] : [
+      ]
+      unless @features.support_component_model?
+        extconf_args.concat([
           # HACK: skip have_devel check since ruby is not installed yet
           "-e",
           "$have_devel = true",
-        ]),
+        ])
+      end
+      extconf_args.concat([
         # HACK: force static ext build by imitating extmk
         "-e",
         "$static = true; trace_var(:$static) {|v| $static = true }",
@@ -115,7 +119,7 @@ module RubyWasm
         %Q(require "json"; File.write("#{metadata_json(crossruby)}", JSON.dump({target: $target}))),
         "-I#{crossruby.build_dir}",
         "--",
-      ]
+      ])
       extconf_args << "--disable-component-model" unless @features.support_component_model?
       # Clear RUBYOPT to avoid loading unrelated bundle setup
       executor.system crossruby.baseruby_path,


### PR DESCRIPTION
We had been using the master Ruby to use the latest Bundler for cross-compilation feature, but we can now use stable 3.4.1 instead.