### PR TITLE
Stop using bundled gems in the example

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,5 @@ group :check do
   # Use the latest version of webrick for URI change in Ruby 3.4
   gem "webrick", "~> 1.8.2"
   gem "syntax_tree", "~> 3.5"
-  gem "steep", "~> 1.9" if RUBY_VERSION >= "3.1.0"
+  gem "steep", "1.10.0" if RUBY_VERSION >= "3.1.0"
 end

--- a/lib/ruby_wasm/build/toolchain.rb
+++ b/lib/ruby_wasm/build/toolchain.rb
@@ -46,7 +46,7 @@ module RubyWasm
     %i[cc cxx ranlib ld ar].each do |name|
       define_method(name) do
         @tools_cache ||= {} #: Hash[String, String]
-        @tools_cache[name] ||= find_tool(name)
+        __skip__ = @tools_cache[name] ||= find_tool(name)
         @tools_cache[name]
       end
     end

--- a/lib/ruby_wasm/packager/component_adapter.rb
+++ b/lib/ruby_wasm/packager/component_adapter.rb
@@ -1,10 +1,8 @@
 module RubyWasm::Packager::ComponentAdapter
-  module_function
-
   # The path to the component adapter for the given WASI execution model.
   #
   # @param exec_model [String] "command" or "reactor"
-  def wasi_snapshot_preview1(exec_model)
+  def self.wasi_snapshot_preview1(exec_model)
     File.join(
       File.dirname(__FILE__),
       "component_adapter",

--- a/packages/npm-packages/ruby-wasm-wasi/example/require_relative/index.html
+++ b/packages/npm-packages/ruby-wasm-wasi/example/require_relative/index.html
@@ -21,13 +21,9 @@
       end
     end
 
-    # "bundle install --standalone" does not care about bundled gems, so we need
-    # to activate them manually.
-    Gem::Dependency.new("csv").to_spec.activate
-
-    # The above patch does not break the original require_relative
-    require 'csv'
-    csv = CSV.new "foo\nbar\n"
+    # The above patch should not break the original require_relative
+    require 'uri'
+    URI.parse('http://example.com')
 
     # Load the main script
     require_relative 'main'

--- a/sig/ruby_wasm/cli.rbs
+++ b/sig/ruby_wasm/cli.rbs
@@ -29,7 +29,10 @@ module RubyWasm
 
     def initialize: (stdout: IO, stderr: IO) -> void
 
+    def run: (Array[String] args) -> void
+
     def build: (Array[String] args) -> void
+    def do_build_with_force_ruby_platform: (cli_options options) -> void
     def pack: (Array[String] args) -> void
 
     private
@@ -49,5 +52,6 @@ module RubyWasm
 
   self.@logger: Logger?
   def self.logger: () -> Logger
+  def self.logger=: (Logger) -> void
   attr_accessor self.log_level: Symbol
 end

--- a/sig/ruby_wasm/packager.rbs
+++ b/sig/ruby_wasm/packager.rbs
@@ -70,8 +70,12 @@ class RubyWasm::Packager
     def build_strategy: () -> BuildStrategy
 
     class BuildStrategy
+      include RubyWasm::_Cacheable
+
       @packager: RubyWasm::Packager
       def initialize: (RubyWasm::Packager) -> void
+      def target: () -> RubyWasm::Target
+      def artifact: () -> string
       def build: (RubyWasm::BuildExecutor, untyped options) -> String
       def specs_with_extensions: () -> Array[[untyped, Array[string]]]
       def build_gem_exts: (RubyWasm::BuildExecutor, string gem_home) -> void


### PR DESCRIPTION
Bundled gems are unavailable as gems when commit hash is specified in the `lib/bundled_gems` file of ruby/ruby because `.gemspec` files are not installed for hash-specified gems.