### PR TITLE
Fix the Gemfile for Ruby 3.4

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -41,7 +41,7 @@ NPM_PACKAGES = [
   {
     name: "ruby-3.4-wasm-wasi",
     ruby_version: "3.4",
-    gemfile: "packages/npm-packages/ruby-3.3-wasm-wasi/Gemfile",
+    gemfile: "packages/npm-packages/ruby-3.4-wasm-wasi/Gemfile",
     target: "wasm32-unknown-wasip1"
   },
   {


### PR DESCRIPTION
Currently, `ruby-3.4-wasm-wasi` uses the Gemfile for Ruby 3.3. I assume this should be for Ruby 3.4.