### PR TITLE
fix(ruby-wasm): make Node able to load ruby+stdlib.wasm from dist/

### DIFF
--- a/packages/npm-packages/ruby-3.2-wasm-wasi/package.json
+++ b/packages/npm-packages/ruby-3.2-wasm-wasi/package.json
@@ -17,11 +17,11 @@
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js"
     },
-    "./*.wasm": {
-      "browser": "./*.wasm",
-      "umd": "./*.wasm",
-      "import": "./*.wasm",
-      "require": "./*.wasm"
+    "./dist/*.wasm": {
+      "browser": "./dist/*.wasm",
+      "umd": "./dist/*.wasm",
+      "import": "./dist/*.wasm",
+      "require": "./dist/*.wasm"
     }
   },
   "files": [

--- a/packages/npm-packages/ruby-3.3-wasm-wasi/package.json
+++ b/packages/npm-packages/ruby-3.3-wasm-wasi/package.json
@@ -17,11 +17,11 @@
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js"
     },
-    "./*.wasm": {
-      "browser": "./*.wasm",
-      "umd": "./*.wasm",
-      "import": "./*.wasm",
-      "require": "./*.wasm"
+    "./dist/*.wasm": {
+      "browser": "./dist/*.wasm",
+      "umd": "./dist/*.wasm",
+      "import": "./dist/*.wasm",
+      "require": "./dist/*.wasm"
     }
   },
   "files": [

--- a/packages/npm-packages/ruby-3.4-wasm-wasi/package.json
+++ b/packages/npm-packages/ruby-3.4-wasm-wasi/package.json
@@ -17,11 +17,11 @@
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js"
     },
-    "./*.wasm": {
-      "browser": "./*.wasm",
-      "umd": "./*.wasm",
-      "import": "./*.wasm",
-      "require": "./*.wasm"
+    "./dist/*.wasm": {
+      "browser": "./dist/*.wasm",
+      "umd": "./dist/*.wasm",
+      "import": "./dist/*.wasm",
+      "require": "./dist/*.wasm"
     }
   },
   "files": [


### PR DESCRIPTION
Hi. Thank you for the great project. I change `exports` to `"./dist/*.wasm": { "import": "./dist/*.wasm", "require": "./dist/*.wasm" }` so sub‑path imports like `@ruby/3.x-wasm-wasi/dist/ruby+stdlib.wasm` resolve correctly.