### PR TITLE
Add `logger` as a dependency

### DIFF
--- a/ruby_wasm.gemspec
+++ b/ruby_wasm.gemspec
@@ -29,4 +29,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.extensions = ["ext/ruby_wasm/Cargo.toml"]
+
+  spec.add_dependency "logger"
 end


### PR DESCRIPTION
`logger` will be a bundled gem from Ruby 3.5.
https://bugs.ruby-lang.org/issues/20309

So if we use `logger` as the standard library, Bundler shows the following warning.

```
$ bundle exec rbwasm build -o ruby.wasm
/3.4.1/lib/ruby/gems/3.4.0/gems/ruby_wasm-2.7.1-x86_64-linux/lib/ruby_wasm.rb:1: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
```

This PR adds the `logger` to runtime dependency to fix the warning.