### PR TITLE
Add require_relative shim file.

### DIFF
--- a/packages/gems/js/lib/js/require_remote.rb
+++ b/packages/gems/js/lib/js/require_remote.rb
@@ -37,7 +37,13 @@ module JS
   #      rescue LoadError
   #        JS::RequireRemote.instance.load(path)
   #      end
-  #   end
+  #    end
+  #
+  # You can also load included shim to achieve the same.
+  #
+  # == Example
+  #
+  #    require 'js/require_remote/relative_shim'
   #
   class RequireRemote
     include Singleton

--- a/packages/gems/js/lib/js/require_remote/relative_shim.rb
+++ b/packages/gems/js/lib/js/require_remote/relative_shim.rb
@@ -1,0 +1,15 @@
+require 'js/require_remote'
+
+module Kernel
+  alias original_require_relative require_relative
+                                                                   
+  def require_relative(path)
+    caller_path = caller_locations(1, 1).first.absolute_path || ''
+    dir = File.dirname(caller_path)
+    file = File.absolute_path(path, dir)
+                                                                   
+    original_require_relative(file)
+  rescue LoadError
+    JS::RequireRemote.instance.load(path)
+  end
+end


### PR DESCRIPTION
In 99% of my usage, I had to include this shim code as stated in docs example. I would really benefit from making it part of the `js` package by default.