### PR TITLE
js: fix build with `RUBY_API_VERSION_MAJOR >= 4`

### DIFF
--- a/packages/gems/js/ext/js/witapi-core.c
+++ b/packages/gems/js/ext/js/witapi-core.c
@@ -310,12 +310,12 @@ uint32_t rb_abi_guest_rb_abi_value_data_ptr(rb_abi_guest_rb_abi_value_t self) {
   return (uint32_t)DATA_PTR(obj);
 }
 
-_Static_assert(RUBY_API_VERSION_MAJOR == 3, "unsupported Ruby version");
-#if RUBY_API_VERSION_MINOR == 2
+#if (RUBY_API_VERSION_MAJOR == 3) && (RUBY_API_VERSION_MINOR == 2)
 void rb_vm_bugreport(const void *);
 
 void rb_abi_guest_rb_vm_bugreport(void) { rb_vm_bugreport(NULL); }
-#elif RUBY_API_VERSION_MINOR >= 3
+#elif ((RUBY_API_VERSION_MAJOR == 3) && RUBY_API_VERSION_MINOR >= 3) ||        \
+    (RUBY_API_VERSION_MAJOR >= 4)
 bool rb_vm_bugreport(const void *, FILE *);
 
 void rb_abi_guest_rb_vm_bugreport(void) { rb_vm_bugreport(NULL, stderr); }


### PR DESCRIPTION
https://github.com/ruby/ruby/commit/6d81969b475262aba251e99b518181bdf7c5a523