### PR TITLE
Add rdoc as an explicit dependency for Ruby 4.0 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :development do
   gem "rake"
   gem "rake-compiler"
   gem "rb_sys", "0.9.108"
+  gem "rdoc", "~> 7.0"
 end
 
 group :check do


### PR DESCRIPTION
This issue occurs specifically on Ruby 4.0.
Ruby 4.0 no longer ships rdoc as a default gem, so `require "rdoc/task"` fails under `bundle exec` unless rdoc is explicitly listed in the Gemfile.

Running `bundle exec rake compile` results in the following error:

```
/home/ledsun/ruby.wasm/rakelib/doc.rake:1: warning: rdoc/task is found in rdoc, which is not part of the default gems
since Ruby 4.0.0.
You can add rdoc to your Gemfile or gemspec to fix this error.
rake aborted!
LoadError: cannot load such file -- rdoc/task (LoadError)
/home/ledsun/ruby.wasm/rakelib/doc.rake:1:in '<top (required)>'
/home/ledsun/.rbenv/versions/4.0.0/bin/bundle:25:in '<main>'
(See full trace by running task with --trace)
```

This change adds rdoc as an explicit dependency to restore compatibility with Ruby 4.0 and ensure reproducible builds.
