### PR TITLE
Fix ruby-head-wasm-wasi builds on Ruby head with host dump_ast

### DIFF
--- a/lib/ruby_wasm/build/product/crossruby.rb
+++ b/lib/ruby_wasm/build/product/crossruby.rb
@@ -322,6 +322,10 @@ module RubyWasm
       File.join(@baseruby.install_dir, "bin/ruby")
     end
 
+    def dump_ast_path
+      File.join(@baseruby.product_build_dir, "dump_ast")
+    end
+
     def configure_args(build_triple, toolchain)
       target = @params.target.triple
       default_exts = @params.default_exts
@@ -336,6 +340,9 @@ module RubyWasm
       args << %Q(--with-zlib-dir=#{@zlib.install_root})
       args << %Q(--with-openssl-dir=#{@openssl.install_root}) if @openssl
       args << %Q(--with-baseruby=#{baseruby_path})
+      # Use the host-built dump_ast so cross builds don't try to execute the
+      # target-side wasm dump_ast while generating .rbinc files.
+      args << %Q(--with-dump-ast=#{dump_ast_path})
 
       case target
       when /^wasm32-unknown-wasi/

--- a/sig/ruby_wasm/build.rbs
+++ b/sig/ruby_wasm/build.rbs
@@ -218,6 +218,7 @@ module RubyWasm
     def extinit_obj: -> String
     def extinit_c_erb: -> String
     def baseruby_path: -> String
+    def dump_ast_path: -> String
     def configure_args: (String build_triple, Toolchain toolchain) -> Array[String]
     def rbconfig_rb: -> String?
   end


### PR DESCRIPTION
## Summary
- pass the host-built `dump_ast` to cross builds alongside `--with-baseruby`
- avoid running the target-side wasm `dump_ast` during `.rbinc` generation on current Ruby head
- declare `dump_ast_path` in RBS and document why the configure argument is needed

## Testing
- `bundle exec rake check:type`

Closes #629.
