### PR TITLE
Fix documentation CDN package versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Create and save an `index.html` page with the following contents:
 
 ```html
 <html>
-  <script src="https://cdn.jsdelivr.net/npm/@ruby/4.0-wasm-wasi@2.9.4/dist/browser.script.iife.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@ruby/4.0-wasm-wasi@2.9.3-2.9.4/dist/browser.script.iife.js"></script>
   <script type="text/ruby">
     require "js"
 

--- a/docs/cheat_sheet.md
+++ b/docs/cheat_sheet.md
@@ -38,7 +38,7 @@ The easiest way to run Ruby on browser is to use `browser.script.iife.js` script
 
 ```html
 <html>
-  <script src="https://cdn.jsdelivr.net/npm/@ruby/4.0-wasm-wasi@2.9.4/dist/browser.script.iife.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@ruby/4.0-wasm-wasi@2.9.3-2.9.4/dist/browser.script.iife.js"></script>
   <script type="text/ruby">
     require "js"
     JS.global[:document].write "Hello, world!"
@@ -51,8 +51,8 @@ If you want to control Ruby VM from JavaScript, you can use `@ruby/wasm-wasi` pa
 ```html
 <html>
   <script type="module">
-    import { DefaultRubyVM } from "https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@2.9.4/dist/browser/+esm";
-    const response = await fetch("https://cdn.jsdelivr.net/npm/@ruby/4.0-wasm-wasi@2.9.4/dist/ruby+stdlib.wasm");
+    import { DefaultRubyVM } from "https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@2.9.3-2.9.4/dist/browser/+esm";
+    const response = await fetch("https://cdn.jsdelivr.net/npm/@ruby/4.0-wasm-wasi@2.9.3-2.9.4/dist/ruby+stdlib.wasm");
     const module = await WebAssembly.compileStreaming(response);
     const { vm } = await DefaultRubyVM(module);
 
@@ -69,11 +69,11 @@ If you want to control Ruby VM from JavaScript, you can use `@ruby/wasm-wasi` pa
 
 ```html
 <html>
-  <script src="https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@2.9.4/dist/browser.umd.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@2.9.3-2.9.4/dist/browser.umd.js"></script>
   <script>
     const main = async () => {
       const { DefaultRubyVM } = window["ruby-wasm-wasi"];
-      const response = await fetch("https://cdn.jsdelivr.net/npm/@ruby/4.0-wasm-wasi@2.9.4/dist/ruby+stdlib.wasm");
+      const response = await fetch("https://cdn.jsdelivr.net/npm/@ruby/4.0-wasm-wasi@2.9.3-2.9.4/dist/ruby+stdlib.wasm");
       const module = await WebAssembly.compileStreaming(response);
       const { vm } = await DefaultRubyVM(module);
 
@@ -128,7 +128,7 @@ end
 
 ```html
 <html>
-  <script src="https://cdn.jsdelivr.net/npm/@ruby/4.0-wasm-wasi@2.9.4/dist/browser.script.iife.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@ruby/4.0-wasm-wasi@2.9.3-2.9.4/dist/browser.script.iife.js"></script>
   <script type="text/ruby" data-eval="async">
     require "js"
 
@@ -143,8 +143,8 @@ Or using `@ruby/wasm-wasi` package API `RubyVM#evalAsync`:
 ```html
 <html>
   <script type="module">
-    import { DefaultRubyVM } from "https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@2.9.4/dist/browser/+esm";
-    const response = await fetch("https://cdn.jsdelivr.net/npm/@ruby/4.0-wasm-wasi@2.9.4/dist/ruby+stdlib.wasm");
+    import { DefaultRubyVM } from "https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@2.9.3-2.9.4/dist/browser/+esm";
+    const response = await fetch("https://cdn.jsdelivr.net/npm/@ruby/4.0-wasm-wasi@2.9.3-2.9.4/dist/ruby+stdlib.wasm");
     const module = await WebAssembly.compileStreaming(response);
     const { vm } = await DefaultRubyVM(module);
 

--- a/packages/npm-packages/ruby-wasm-wasi/example/hello.html
+++ b/packages/npm-packages/ruby-wasm-wasi/example/hello.html
@@ -1,5 +1,5 @@
 <html>
-  <script src="https://cdn.jsdelivr.net/npm/@ruby/head-wasm-wasi@2.9.4/dist/browser.script.iife.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@ruby/head-wasm-wasi@2.9.3-2.9.4/dist/browser.script.iife.js"></script>
   <script type="text/ruby">
     puts "Hello, world!"
   </script>

--- a/packages/npm-packages/ruby-wasm-wasi/example/lucky.html
+++ b/packages/npm-packages/ruby-wasm-wasi/example/lucky.html
@@ -1,5 +1,5 @@
 <html>
-  <script src="https://cdn.jsdelivr.net/npm/@ruby/head-wasm-wasi@2.9.4/dist/browser.script.iife.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@ruby/head-wasm-wasi@2.9.3-2.9.4/dist/browser.script.iife.js"></script>
   <button id="draw">Draw Omikuji</button>
   <div id="result"></div>
   <script type="text/ruby">

--- a/packages/npm-packages/ruby-wasm-wasi/example/script-src/index.html
+++ b/packages/npm-packages/ruby-wasm-wasi/example/script-src/index.html
@@ -1,4 +1,4 @@
 <html>
-  <script src="https://cdn.jsdelivr.net/npm/@ruby/head-wasm-wasi@2.9.4/dist/browser.script.iife.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@ruby/head-wasm-wasi@2.9.3-2.9.4/dist/browser.script.iife.js"></script>
   <script type="text/ruby" src="hello.rb"></script>
 </html>


### PR DESCRIPTION
 
I have updated the quick sample and related cheat sheet examples in the README to use the published package version `2.9.3-2.9.4`.

Fixed #640.
Since the previous `@2.9.4` package version was not published on npm/jsDelivr, the browser script URL in the README was returning a 404 error.


