### PR TITLE
Remove obsolete WASI Node flag

### DIFF
--- a/docs/cheat_sheet.md
+++ b/docs/cheat_sheet.md
@@ -26,10 +26,10 @@ const { vm } = await DefaultRubyVM(module);
 vm.eval(`puts "hello world"`);
 ```
 
-Then run the example code with `--experimental-wasi-unstable-preview1` flag to enable WASI support:
+Then run the example code:
 
 ```console
-$ node --experimental-wasi-unstable-preview1 index.mjs
+$ node index.mjs
 ```
 
 ## Browser

--- a/packages/npm-packages/ruby-wasm-wasi/example/README.md
+++ b/packages/npm-packages/ruby-wasm-wasi/example/README.md
@@ -15,5 +15,5 @@ $ # Open http://localhost:8000/script-src
 
 ```console
 $ npm install
-$ node --experimental-wasi-unstable-preview1 index.node.js
+$ node index.node.js
 ```

--- a/packages/npm-packages/ruby-wasm-wasi/example/index.node.js
+++ b/packages/npm-packages/ruby-wasm-wasi/example/index.node.js
@@ -1,7 +1,7 @@
 import fs from "fs/promises";
 import { DefaultRubyVM } from "@ruby/wasm-wasi/dist/node";
 
-// $ node --experimental-wasi-unstable-preview1 index.node.js
+// $ node index.node.js
 
 const main = async () => {
   const binary = await fs.readFile(

--- a/packages/npm-packages/ruby-wasm-wasi/tools/run-test-unit.mjs
+++ b/packages/npm-packages/ruby-wasm-wasi/tools/run-test-unit.mjs
@@ -1,5 +1,5 @@
 #!/bin/sh
-":" //# ; exec /usr/bin/env node --experimental-wasi-unstable-preview1 "$0" "$@"
+":" //# ; exec /usr/bin/env node "$0" "$@"
 
 import * as browserWasi from "@bjorn3/browser_wasi_shim";
 import * as preview2Shim from "@bytecodealliance/preview2-shim"

--- a/packages/npm-packages/ruby-wasm-wasi/vitest.config.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     pool: "forks",
     poolOptions: {
       forks: {
-        execArgv: ["--experimental-wasi-unstable-preview1", "--expose-gc"],
+        execArgv: ["--expose-gc"],
       }
     },
     testTimeout: 300000,


### PR DESCRIPTION
## Summary
- remove the obsolete `--experimental-wasi-unstable-preview1` flag from Node.js examples and docs
- remove the same flag from Node-based unit and Vitest test runners

Additionally, GitHub Actions workflows already use Node.js 22.20.0 to run `npm tests`.

## Reason
WASI is enabled by default in Node.js 20.0.0 and later.
Versions of Node.js prior to 20.0.0 have already reached end-of-life.
I believe this flag is unnecessary for older versions of Node.js.


