### PR TITLE
Add Ruby::Box example

### DIFF
--- a/packages/npm-packages/ruby-wasm-wasi/example/README.md
+++ b/packages/npm-packages/ruby-wasm-wasi/example/README.md
@@ -16,4 +16,5 @@ $ # Open http://localhost:8000/script-src
 ```console
 $ npm install
 $ node --experimental-wasi-unstable-preview1 index.node.js
+$ node ruby-box.node.js
 ```

--- a/packages/npm-packages/ruby-wasm-wasi/example/ruby-box.node.js
+++ b/packages/npm-packages/ruby-wasm-wasi/example/ruby-box.node.js
@@ -1,0 +1,28 @@
+import fs from "fs/promises";
+import { DefaultRubyVM } from "@ruby/wasm-wasi/dist/node";
+
+// $ node ruby-box.node.js
+
+const main = async () => {
+  const binary = await fs.readFile(
+    "./node_modules/@ruby/head-wasm-wasi/dist/ruby.wasm",
+  );
+  const module = await WebAssembly.compile(binary);
+  const { vm } = await DefaultRubyVM(module, {
+    env: {
+      RUBY_BOX: "1",
+    },
+  });
+
+  vm.eval(`
+    box = Ruby::Box.new
+    box.eval <<~RUBY
+      X = 123
+    RUBY
+
+    puts "Ruby::Box.enabled?: #{Ruby::Box.enabled?}"
+    puts "box::X: #{box::X}"
+  `);
+};
+
+main();


### PR DESCRIPTION
I'll keep this pull request as a draft until I've prepared automated tests for the Node.js examples.

## Summary
- add a Node.js example showing how to enable Ruby::Box with RUBY_BOX=1 when creating DefaultRubyVM
- document the new example command in the ruby-wasm-wasi example README

## How It Works
Run the following commands in the `packages/npm-packages/ruby-wasm-wasi/example` directory.

```
npm install
node ruby-box.node.js
```

Output:

```
(node:7650) ExperimentalWarning: WASI is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
ruby.wasm: warning: Ruby::Box is experimental, and the behavior may change in the future!
See https://docs.ruby-lang.org/en/master/Ruby/Box.html for known issues, etc.
Ruby::Box.enabled?: true
box::X: 123
```