### PR TITLE
Update ruby-wasm-wasi dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,28 +24,55 @@
             "license": "MIT OR Apache-2.0"
         },
         "node_modules/@bytecodealliance/componentize-js": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/@bytecodealliance/componentize-js/-/componentize-js-0.14.0.tgz",
-            "integrity": "sha512-Y53lxcHEQz5k4PwqBY3+q6Y+TmFSu5mWhd+2dyURE7mk0GDaFYKRDoATCoXxD8Dvq/HgNPrDSE2X7AJIjPMtYQ==",
+            "version": "0.20.0",
+            "resolved": "https://registry.npmjs.org/@bytecodealliance/componentize-js/-/componentize-js-0.20.0.tgz",
+            "integrity": "sha512-JPRYUTD8v1QUsZ5eqhCtQR7amOTugjV2ofSjFv1/zAGksf4AZUoCFYiKTQ61E+hKUVNJKIdYLOw+stGqAL9qAg==",
             "dev": true,
+            "workspaces": [
+                "."
+            ],
             "dependencies": {
-                "@bytecodealliance/jco": "^1.7.1",
-                "@bytecodealliance/weval": "^0.3.2",
-                "@bytecodealliance/wizer": "^7.0.5",
-                "es-module-lexer": "^1.5.4"
+                "@bytecodealliance/jco": "^1.15.1",
+                "@bytecodealliance/weval": "^0.4.1",
+                "@bytecodealliance/wizer": "^10.0.0",
+                "es-module-lexer": "^1.6.0",
+                "oxc-parser": "^0.76.0"
+            },
+            "bin": {
+                "componentize-js": "src/cli.js"
             }
         },
-        "node_modules/@bytecodealliance/componentize-js/node_modules/@bytecodealliance/jco": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-1.8.1.tgz",
-            "integrity": "sha512-mYjE7lrSWEzFD6lAVA4skm9/6DvorFjuO5DHoxzwWlJ2hKyO/d9t0Wx1V0nT5L1s7+98ZtVSB1emYLNMebpMdA==",
+        "node_modules/@bytecodealliance/componentize-js-0-19-3": {
+            "name": "@bytecodealliance/componentize-js",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@bytecodealliance/componentize-js/-/componentize-js-0.19.3.tgz",
+            "integrity": "sha512-ju7Y4WeF0B9uMkSPHJgmT6ouEfSwbe9M1uR/YOnYZjBpxJjH9qzxIkJg/kf8NycVDyFJ2/lscmJ1E1uPiDQVRQ==",
             "dev": true,
+            "workspaces": [
+                "."
+            ],
             "dependencies": {
-                "@bytecodealliance/componentize-js": "^0.14.0",
-                "@bytecodealliance/preview2-shim": "^0.17.1",
-                "binaryen": "^120.0.0",
-                "chalk-template": "^1",
-                "commander": "^12",
+                "@bytecodealliance/jco": "^1.15.1",
+                "@bytecodealliance/wizer": "^10.0.0",
+                "es-module-lexer": "^1.6.0",
+                "oxc-parser": "^0.76.0"
+            },
+            "bin": {
+                "componentize-js": "src/cli.js"
+            }
+        },
+        "node_modules/@bytecodealliance/componentize-js-0-19-3/node_modules/@bytecodealliance/jco": {
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-1.19.0.tgz",
+            "integrity": "sha512-I57cVbL24/u/zCBwHq7D9PyIMP81hFFYF4hL/pW5biRGVLQAZuwEAUaEmghOouyt77bU2ExqscP2wkLvr3nfDw==",
+            "dev": true,
+            "license": "(Apache-2.0 WITH LLVM-exception)",
+            "dependencies": {
+                "@bytecodealliance/componentize-js": "^0.20.0",
+                "@bytecodealliance/componentize-js-0-19-3": "npm:@bytecodealliance/componentize-js@^0.19.3",
+                "@bytecodealliance/preview2-shim": "^0.17.9",
+                "binaryen": "^123.0.0",
+                "commander": "^14",
                 "mkdirp": "^3",
                 "ora": "^8",
                 "terser": "^5"
@@ -54,11 +81,12 @@
                 "jco": "src/jco.js"
             }
         },
-        "node_modules/@bytecodealliance/componentize-js/node_modules/binaryen": {
-            "version": "120.0.0",
-            "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-120.0.0.tgz",
-            "integrity": "sha512-MaNC1qW5ubk5S7MNNxNpAb9ivKp6TAf8CDknRk4XeCC2wkrpdaubK10S1CAwUXaDDF54gZLtk6opzbEA9VTtJw==",
+        "node_modules/@bytecodealliance/componentize-js-0-19-3/node_modules/binaryen": {
+            "version": "123.0.0",
+            "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-123.0.0.tgz",
+            "integrity": "sha512-/hls/a309aZCc0itqP6uhoR+5DsKSlJVfB8Opd2BY9Ndghs84IScTunlyidyF4r2Xe3lQttnfBNIDjaNpj6mTw==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "wasm-as": "bin/wasm-as",
                 "wasm-ctor-eval": "bin/wasm-ctor-eval",
@@ -70,6 +98,78 @@
                 "wasm-shell": "bin/wasm-shell",
                 "wasm2js": "bin/wasm2js"
             }
+        },
+        "node_modules/@bytecodealliance/componentize-js-0-19-3/node_modules/commander": {
+            "version": "14.0.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+            "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@bytecodealliance/componentize-js-0-19-3/node_modules/es-module-lexer": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@bytecodealliance/componentize-js/node_modules/@bytecodealliance/jco": {
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-1.19.0.tgz",
+            "integrity": "sha512-I57cVbL24/u/zCBwHq7D9PyIMP81hFFYF4hL/pW5biRGVLQAZuwEAUaEmghOouyt77bU2ExqscP2wkLvr3nfDw==",
+            "dev": true,
+            "license": "(Apache-2.0 WITH LLVM-exception)",
+            "dependencies": {
+                "@bytecodealliance/componentize-js": "^0.20.0",
+                "@bytecodealliance/componentize-js-0-19-3": "npm:@bytecodealliance/componentize-js@^0.19.3",
+                "@bytecodealliance/preview2-shim": "^0.17.9",
+                "binaryen": "^123.0.0",
+                "commander": "^14",
+                "mkdirp": "^3",
+                "ora": "^8",
+                "terser": "^5"
+            },
+            "bin": {
+                "jco": "src/jco.js"
+            }
+        },
+        "node_modules/@bytecodealliance/componentize-js/node_modules/binaryen": {
+            "version": "123.0.0",
+            "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-123.0.0.tgz",
+            "integrity": "sha512-/hls/a309aZCc0itqP6uhoR+5DsKSlJVfB8Opd2BY9Ndghs84IScTunlyidyF4r2Xe3lQttnfBNIDjaNpj6mTw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "wasm-as": "bin/wasm-as",
+                "wasm-ctor-eval": "bin/wasm-ctor-eval",
+                "wasm-dis": "bin/wasm-dis",
+                "wasm-merge": "bin/wasm-merge",
+                "wasm-metadce": "bin/wasm-metadce",
+                "wasm-opt": "bin/wasm-opt",
+                "wasm-reduce": "bin/wasm-reduce",
+                "wasm-shell": "bin/wasm-shell",
+                "wasm2js": "bin/wasm2js"
+            }
+        },
+        "node_modules/@bytecodealliance/componentize-js/node_modules/commander": {
+            "version": "14.0.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+            "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@bytecodealliance/componentize-js/node_modules/es-module-lexer": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@bytecodealliance/jco": {
             "version": "1.4.4",
@@ -96,16 +196,17 @@
             "dev": true
         },
         "node_modules/@bytecodealliance/preview2-shim": {
-            "version": "0.17.2",
-            "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.17.2.tgz",
-            "integrity": "sha512-mNm/lblgES8UkVle8rGImXOz4TtL3eU3inHay/7TVchkKrb/lgcVvTK0+VAw8p5zQ0rgQsXm1j5dOlAAd+MeoA==",
+            "version": "0.17.9",
+            "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.17.9.tgz",
+            "integrity": "sha512-i0R3eQBe6PA/o/1EFE3Owe4In2rcccb6QxnjpntM/lPe3/duJ0bRQTVZM2Ufpo99X4eofGeltQUkape1C91FFA==",
             "license": "(Apache-2.0 WITH LLVM-exception)"
         },
         "node_modules/@bytecodealliance/weval": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@bytecodealliance/weval/-/weval-0.3.3.tgz",
-            "integrity": "sha512-hrQI47O1l3ilFscixu0uuSJTj5tbQW0QmCATQWWNW0E8wJxbKH4yo8y57O5gqpRSKk/T+da1sH/GJNrnGHTFNA==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@bytecodealliance/weval/-/weval-0.4.1.tgz",
+            "integrity": "sha512-vJegSAkNjENhJcMUod76KUGAgQLdACDDCwB3JwyR14zDhyHVPAvArvtDDYEEi+c+ELzls62H6wxTvzRmaYTaqg==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "@napi-rs/lzma": "^1.1.2",
                 "decompress": "^4.2.1",
@@ -117,10 +218,11 @@
             }
         },
         "node_modules/@bytecodealliance/wizer": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer/-/wizer-7.0.5.tgz",
-            "integrity": "sha512-xIbLzKxmUNaPwDWorcGtdxh1mcgDiXI8fe9KiDaSICKfCl9VtUKVyXIc3ix+VpwFczBbdhek+TlMiiCf+9lpOQ==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer/-/wizer-10.0.0.tgz",
+            "integrity": "sha512-ziWmovyu1jQl9TsKlfC2bwuUZwxVPFHlX4fOqTzxhgS76jITIo45nzODEwPgU+jjmOr8F3YX2V2wAChC5NKujg==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "wizer": "wizer.js"
             },
@@ -128,22 +230,23 @@
                 "node": ">=16"
             },
             "optionalDependencies": {
-                "@bytecodealliance/wizer-darwin-arm64": "7.0.5",
-                "@bytecodealliance/wizer-darwin-x64": "7.0.5",
-                "@bytecodealliance/wizer-linux-arm64": "7.0.5",
-                "@bytecodealliance/wizer-linux-s390x": "7.0.5",
-                "@bytecodealliance/wizer-linux-x64": "7.0.5",
-                "@bytecodealliance/wizer-win32-x64": "7.0.5"
+                "@bytecodealliance/wizer-darwin-arm64": "10.0.0",
+                "@bytecodealliance/wizer-darwin-x64": "10.0.0",
+                "@bytecodealliance/wizer-linux-arm64": "10.0.0",
+                "@bytecodealliance/wizer-linux-s390x": "10.0.0",
+                "@bytecodealliance/wizer-linux-x64": "10.0.0",
+                "@bytecodealliance/wizer-win32-x64": "10.0.0"
             }
         },
         "node_modules/@bytecodealliance/wizer-darwin-arm64": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-darwin-arm64/-/wizer-darwin-arm64-7.0.5.tgz",
-            "integrity": "sha512-Tp0SgVQR568SVPvSfyWDT00yL4ry/w9FS2qy8ZwaP0EauYyjFSZojj6mESX6x9fpYkEnQdprgfdvhw5h1hTwCQ==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-darwin-arm64/-/wizer-darwin-arm64-10.0.0.tgz",
+            "integrity": "sha512-dhZTWel+xccGTKSJtI9A7oM4yyP20FWflsT+AoqkOqkCY7kCNrj4tmMtZ6GXZFRDkrPY5+EnOh62sfShEibAMA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "darwin"
@@ -153,13 +256,14 @@
             }
         },
         "node_modules/@bytecodealliance/wizer-darwin-x64": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-darwin-x64/-/wizer-darwin-x64-7.0.5.tgz",
-            "integrity": "sha512-HYmG5Q9SpQJnqR7kimb5J3VAh6E62b30GLG/E+6doS/UwNhSpSmYjaggVfuJvgFDbUxsnD1l36qZny0xMwxikA==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-darwin-x64/-/wizer-darwin-x64-10.0.0.tgz",
+            "integrity": "sha512-r/LUIZw6Q3Hf4htd46mD+EBxfwjBkxVIrTM1r+B2pTCddoBYQnKVdVsI4UFyy7NoBxzEg8F8BwmTNoSLmFRjpw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "darwin"
@@ -169,13 +273,14 @@
             }
         },
         "node_modules/@bytecodealliance/wizer-linux-arm64": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-linux-arm64/-/wizer-linux-arm64-7.0.5.tgz",
-            "integrity": "sha512-01qqaiIWrYXPt2bjrfiluSSOmUL/PMjPtJlYa/XqZgK75g3RVn3sRkSflwoCXtXMRbHdb03qNrJ9w81+F17kvA==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-linux-arm64/-/wizer-linux-arm64-10.0.0.tgz",
+            "integrity": "sha512-pGSfFWXzeTqHm6z1PtVaEn+7Fm3QGC8YnHrzBV4sQDVS3N1NwmuHZAc8kslmlFPNdu61ycEvdOsSgCny8JPQvg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
@@ -185,13 +290,14 @@
             }
         },
         "node_modules/@bytecodealliance/wizer-linux-s390x": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-linux-s390x/-/wizer-linux-s390x-7.0.5.tgz",
-            "integrity": "sha512-smGfD4eJou81g6yDlV7MCRoKgKlqd4SQL00pHxQGrNfUPnfYKhZ4z80N9J9T2B++uo2FM14BFilsRrV5UevKlA==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-linux-s390x/-/wizer-linux-s390x-10.0.0.tgz",
+            "integrity": "sha512-O8vHxRTAdb1lUnVXMIMTcp/9q4pq1D4iIKigJCipg2JN15taV9uFAWh0fO88wylXwuSlO7dOE1AwQl54fMKXQg==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
@@ -201,13 +307,14 @@
             }
         },
         "node_modules/@bytecodealliance/wizer-linux-x64": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-linux-x64/-/wizer-linux-x64-7.0.5.tgz",
-            "integrity": "sha512-lxMb25jLd6n+hhjPhlqRBnBdGRumKkcEavqJ3p4OAtjr6pEPdbSfSVmYDt9LnvtqmqQSnUCtFRRr5J2BmQ3SkQ==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-linux-x64/-/wizer-linux-x64-10.0.0.tgz",
+            "integrity": "sha512-fJtM1sy43FBMnp+xpapFX6U1YdTBKA/1T4CYfG/qeE8jn0SXk2EuiYoY/EnC2uyNy9hjTrvfdYO5n4MXW0EIdQ==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
@@ -217,13 +324,14 @@
             }
         },
         "node_modules/@bytecodealliance/wizer-win32-x64": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-win32-x64/-/wizer-win32-x64-7.0.5.tgz",
-            "integrity": "sha512-eUY9a82HR20qIfyEffWdJZj7k4GH2wGaZpr70dinDy8Q648LeQayL0Z6FW5nApoezjy+CIBj0Mv+rHUASV9Jzw==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-win32-x64/-/wizer-win32-x64-10.0.0.tgz",
+            "integrity": "sha512-55BPLfGT7iT7gH5M69NpTM16QknJZ7OxJ0z73VOEoeGA9CT8QPKMRzFKsPIvLs+W8G28fdudFA94nElrdkp3Kg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "win32"
@@ -233,434 +341,37 @@
             }
         },
         "node_modules/@emnapi/core": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.3.1.tgz",
-            "integrity": "sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/wasi-threads": "1.0.1",
+                "@emnapi/wasi-threads": "1.2.1",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
-            "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/wasi-threads": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.1.tgz",
-            "integrity": "sha512-iIBu7mwkq4UQGeMEM8bLwNK962nXdhodeScX4slfQnRhEMMzvYivHhutCIk8uojvmASXXPC2WNEjwxFWk72Oqw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
-            "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "aix"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/android-arm": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
-            "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/android-arm64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
-            "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/android-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
-            "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
-            "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/darwin-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
-            "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
-            "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
-            "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-arm": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
-            "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-arm64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
-            "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-ia32": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
-            "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-loong64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
-            "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
-            "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
-            "cpu": [
-                "mips64el"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
-            "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
-            "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-s390x": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
-            "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
-            "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
-            "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
-            "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
-            "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
-            "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/sunos-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
-            "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-arm64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
-            "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-ia32": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
-            "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
-            "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/@gerrit0/mini-shiki": {
@@ -723,9 +434,9 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "dev": true,
             "license": "MIT"
         },
@@ -741,10 +452,11 @@
             }
         },
         "node_modules/@napi-rs/lzma": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/lzma/-/lzma-1.4.1.tgz",
-            "integrity": "sha512-5f8K9NHjwHjZKGm3SS+7CFxXQhz8rbg2umBm/9g0xQRXBdYEI31N5z1ACuk9bmBQOusXAq9CArGfs/ZQso2rUA==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma/-/lzma-1.4.5.tgz",
+            "integrity": "sha512-zS5LuN1OBPAyZpda2ZZgYOEDC+xecUdAGnrvbYzjnLXkrq/OBC3B9qcRvlxbDR3k5H/gVfvef1/jyUqPknqjbg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 10"
             },
@@ -753,33 +465,34 @@
                 "url": "https://github.com/sponsors/Brooooooklyn"
             },
             "optionalDependencies": {
-                "@napi-rs/lzma-android-arm-eabi": "1.4.1",
-                "@napi-rs/lzma-android-arm64": "1.4.1",
-                "@napi-rs/lzma-darwin-arm64": "1.4.1",
-                "@napi-rs/lzma-darwin-x64": "1.4.1",
-                "@napi-rs/lzma-freebsd-x64": "1.4.1",
-                "@napi-rs/lzma-linux-arm-gnueabihf": "1.4.1",
-                "@napi-rs/lzma-linux-arm64-gnu": "1.4.1",
-                "@napi-rs/lzma-linux-arm64-musl": "1.4.1",
-                "@napi-rs/lzma-linux-ppc64-gnu": "1.4.1",
-                "@napi-rs/lzma-linux-riscv64-gnu": "1.4.1",
-                "@napi-rs/lzma-linux-s390x-gnu": "1.4.1",
-                "@napi-rs/lzma-linux-x64-gnu": "1.4.1",
-                "@napi-rs/lzma-linux-x64-musl": "1.4.1",
-                "@napi-rs/lzma-wasm32-wasi": "1.4.1",
-                "@napi-rs/lzma-win32-arm64-msvc": "1.4.1",
-                "@napi-rs/lzma-win32-ia32-msvc": "1.4.1",
-                "@napi-rs/lzma-win32-x64-msvc": "1.4.1"
+                "@napi-rs/lzma-android-arm-eabi": "1.4.5",
+                "@napi-rs/lzma-android-arm64": "1.4.5",
+                "@napi-rs/lzma-darwin-arm64": "1.4.5",
+                "@napi-rs/lzma-darwin-x64": "1.4.5",
+                "@napi-rs/lzma-freebsd-x64": "1.4.5",
+                "@napi-rs/lzma-linux-arm-gnueabihf": "1.4.5",
+                "@napi-rs/lzma-linux-arm64-gnu": "1.4.5",
+                "@napi-rs/lzma-linux-arm64-musl": "1.4.5",
+                "@napi-rs/lzma-linux-ppc64-gnu": "1.4.5",
+                "@napi-rs/lzma-linux-riscv64-gnu": "1.4.5",
+                "@napi-rs/lzma-linux-s390x-gnu": "1.4.5",
+                "@napi-rs/lzma-linux-x64-gnu": "1.4.5",
+                "@napi-rs/lzma-linux-x64-musl": "1.4.5",
+                "@napi-rs/lzma-wasm32-wasi": "1.4.5",
+                "@napi-rs/lzma-win32-arm64-msvc": "1.4.5",
+                "@napi-rs/lzma-win32-ia32-msvc": "1.4.5",
+                "@napi-rs/lzma-win32-x64-msvc": "1.4.5"
             }
         },
         "node_modules/@napi-rs/lzma-android-arm-eabi": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-android-arm-eabi/-/lzma-android-arm-eabi-1.4.1.tgz",
-            "integrity": "sha512-yenreSpZ9IrqppJOiWDqWMmja7XtSgio9LhtxYwgdILmy/OJTe/mlTYv+FhJBf7hIV9Razu5eBuEa3zKri81IA==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-android-arm-eabi/-/lzma-android-arm-eabi-1.4.5.tgz",
+            "integrity": "sha512-Up4gpyw2SacmyKWWEib06GhiDdF+H+CCU0LAV8pnM4aJIDqKKd5LHSlBht83Jut6frkB0vwEPmAkv4NjQ5u//Q==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
@@ -789,13 +502,14 @@
             }
         },
         "node_modules/@napi-rs/lzma-android-arm64": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-android-arm64/-/lzma-android-arm64-1.4.1.tgz",
-            "integrity": "sha512-piutVBz5B1TNxXeEjub0n/IKI6dMaXPPRbVSXuc4gnZgzcihNDUh68vcLZgYd+IMiACZvBxvx2O3t5nthtph3A==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-android-arm64/-/lzma-android-arm64-1.4.5.tgz",
+            "integrity": "sha512-uwa8sLlWEzkAM0MWyoZJg0JTD3BkPknvejAFG2acUA1raXM8jLrqujWCdOStisXhqQjZ2nDMp3FV6cs//zjfuQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
@@ -805,13 +519,14 @@
             }
         },
         "node_modules/@napi-rs/lzma-darwin-arm64": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-darwin-arm64/-/lzma-darwin-arm64-1.4.1.tgz",
-            "integrity": "sha512-sDfOhQQFqV8lGbpgJN9DqNLBPR7QOfYjcWUv8FOGPaVP1LPJDnrc5uCpRWWEa2zIKmTiO8P9xzIl0TDzrYmghg==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-darwin-arm64/-/lzma-darwin-arm64-1.4.5.tgz",
+            "integrity": "sha512-0Y0TQLQ2xAjVabrMDem1NhIssOZzF/y/dqetc6OT8mD3xMTDtF8u5BqZoX3MyPc9FzpsZw4ksol+w7DsxHrpMA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -821,13 +536,14 @@
             }
         },
         "node_modules/@napi-rs/lzma-darwin-x64": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-darwin-x64/-/lzma-darwin-x64-1.4.1.tgz",
-            "integrity": "sha512-S5/RbC6EP4QkYy2xhxbfm48ZD9FkysfpWY4Slve0nj5RGGsHvcJBg2Pi69jrTPB/zLKz2SUa0i+RfUt9zvZNaw==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-darwin-x64/-/lzma-darwin-x64-1.4.5.tgz",
+            "integrity": "sha512-vR2IUyJY3En+V1wJkwmbGWcYiT8pHloTAWdW4pG24+51GIq+intst6Uf6D/r46citObGZrlX0QvMarOkQeHWpw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -837,13 +553,14 @@
             }
         },
         "node_modules/@napi-rs/lzma-freebsd-x64": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-freebsd-x64/-/lzma-freebsd-x64-1.4.1.tgz",
-            "integrity": "sha512-4AFnq6aZnclwameSBkDWu5Ftb8y4GwvVXeQXJKbN7hf7O5GG/8QpQB1R1NJw2QORUhpKwjAQUpbkTyhL2GFWWw==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-freebsd-x64/-/lzma-freebsd-x64-1.4.5.tgz",
+            "integrity": "sha512-XpnYQC5SVovO35tF0xGkbHYjsS6kqyNCjuaLQ2dbEblFRr5cAZVvsJ/9h7zj/5FluJPJRDojVNxGyRhTp4z2lw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
@@ -853,13 +570,14 @@
             }
         },
         "node_modules/@napi-rs/lzma-linux-arm-gnueabihf": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm-gnueabihf/-/lzma-linux-arm-gnueabihf-1.4.1.tgz",
-            "integrity": "sha512-j5rL1YRIm6rWmmGAvN6DPX6QuRjvFGB93xJ7DTRB47GXW4zHekXae6ivowjJ95vT4Iz4hSWkZbuwAy95eFrWRA==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm-gnueabihf/-/lzma-linux-arm-gnueabihf-1.4.5.tgz",
+            "integrity": "sha512-ic1ZZMoRfRMwtSwxkyw4zIlbDZGC6davC9r+2oX6x9QiF247BRqqT94qGeL5ZP4Vtz0Hyy7TEViWhx5j6Bpzvw==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -869,13 +587,17 @@
             }
         },
         "node_modules/@napi-rs/lzma-linux-arm64-gnu": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm64-gnu/-/lzma-linux-arm64-gnu-1.4.1.tgz",
-            "integrity": "sha512-1XdFGKyTS9m+VrRQYs9uz+ToHf4Jwm0ejHU48k9lT9MPl8jSqzKdVtFzZBPzronHteSynBfKmUq0+HeWmjrsOQ==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm64-gnu/-/lzma-linux-arm64-gnu-1.4.5.tgz",
+            "integrity": "sha512-asEp7FPd7C1Yi6DQb45a3KPHKOFBSfGuJWXcAd4/bL2Fjetb2n/KK2z14yfW8YC/Fv6x3rBM0VAZKmJuz4tysg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -885,13 +607,17 @@
             }
         },
         "node_modules/@napi-rs/lzma-linux-arm64-musl": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm64-musl/-/lzma-linux-arm64-musl-1.4.1.tgz",
-            "integrity": "sha512-9d09tYS0/rBwIk1QTcO2hMZEB/ZpsG2+uFW5am1RHElSWMclObirB1An7b6AMDJcRvcomkOg2GZ9COzrvHKwEA==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm64-musl/-/lzma-linux-arm64-musl-1.4.5.tgz",
+            "integrity": "sha512-yWjcPDgJ2nIL3KNvi4536dlT/CcCWO0DUyEOlBs/SacG7BeD6IjGh6yYzd3/X1Y3JItCbZoDoLUH8iB1lTXo3w==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -901,13 +627,17 @@
             }
         },
         "node_modules/@napi-rs/lzma-linux-ppc64-gnu": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-ppc64-gnu/-/lzma-linux-ppc64-gnu-1.4.1.tgz",
-            "integrity": "sha512-UzEkmsgoJ3IOGIRb6kBzNiw+ThUpiighop7dVYfSqlF5juGzwf7YewC57RGn4FoJCvadOCrSm5VikAcgrwVgAw==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-ppc64-gnu/-/lzma-linux-ppc64-gnu-1.4.5.tgz",
+            "integrity": "sha512-0XRhKuIU/9ZjT4WDIG/qnX7Xz7mSQHYZo9Gb3MP2gcvBgr6BA4zywQ9k3gmQaPn9ECE+CZg2V7DV7kT+x2pUMQ==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -917,13 +647,17 @@
             }
         },
         "node_modules/@napi-rs/lzma-linux-riscv64-gnu": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-riscv64-gnu/-/lzma-linux-riscv64-gnu-1.4.1.tgz",
-            "integrity": "sha512-9dUKlZ1PdwxTaFF+j3oc+xjlk9nqFwo1NWWOH30uwjl4Rm5Gkv+Fx0pHrzu4kR/iVA+oyQqa9/2uDYnGSTijBA==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-riscv64-gnu/-/lzma-linux-riscv64-gnu-1.4.5.tgz",
+            "integrity": "sha512-QrqDIPEUUB23GCpyQj/QFyMlr8SGxxyExeZz9OWFnHfb70kXdTLWrHS/hEI1Ru+lSbQ/6xRqeoGyQ4Aqdg+/RA==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -933,13 +667,17 @@
             }
         },
         "node_modules/@napi-rs/lzma-linux-s390x-gnu": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-s390x-gnu/-/lzma-linux-s390x-gnu-1.4.1.tgz",
-            "integrity": "sha512-MOVXUWJSLLCJDCCAlGa39sh7nv9XjvXzCf7QJus7rD8Ciz0mpXNXF9mg0ji7/MZ7pZlKPlXjXDnpVCfFdSEaFQ==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-s390x-gnu/-/lzma-linux-s390x-gnu-1.4.5.tgz",
+            "integrity": "sha512-k8RVM5aMhW86E9H0QXdquwojew4H3SwPxbRVbl49/COJQWCUjGi79X6mYruMnMPEznZinUiT1jgKbFo2A00NdA==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -949,13 +687,17 @@
             }
         },
         "node_modules/@napi-rs/lzma-linux-x64-gnu": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.4.1.tgz",
-            "integrity": "sha512-Sxu7aJxU1sDbUTqjqLVDV3DCOAlbsFKvmuCN/S5uXBJd1IF2wJ9jK3NbFzfqTAo5Hudx8Y7kOb6+3K+fYPI1KQ==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.4.5.tgz",
+            "integrity": "sha512-6rMtBgnIq2Wcl1rQdZsnM+rtCcVCbws1nF8S2NzaUsVaZv8bjrPiAa0lwg4Eqnn1d9lgwqT+cZgm5m+//K08Kw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -965,13 +707,17 @@
             }
         },
         "node_modules/@napi-rs/lzma-linux-x64-musl": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-musl/-/lzma-linux-x64-musl-1.4.1.tgz",
-            "integrity": "sha512-4I3BeKBQJSE5gF2/VTEv7wCLLjhapeutbCGpZPmDiLHZ74rm9edmNXAlKpdjADQ4YDLJ2GIBzttvwLXkJ9U+cw==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-musl/-/lzma-linux-x64-musl-1.4.5.tgz",
+            "integrity": "sha512-eiadGBKi7Vd0bCArBUOO/qqRYPHt/VQVvGyYvDFt6C2ZSIjlD+HuOl+2oS1sjf4CFjK4eDIog6EdXnL0NE6iyQ==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -981,29 +727,31 @@
             }
         },
         "node_modules/@napi-rs/lzma-wasm32-wasi": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-wasm32-wasi/-/lzma-wasm32-wasi-1.4.1.tgz",
-            "integrity": "sha512-s32HdKqQWbohf6DGWpG9YMODaBdbKJ++JpNr6Ii7821sKf4h/o+p8IRFTOaWdmdJdllEWlRirnd5crA29VivJQ==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-wasm32-wasi/-/lzma-wasm32-wasi-1.4.5.tgz",
+            "integrity": "sha512-+VyHHlr68dvey6fXc2hehw9gHVFIW3TtGF1XkcbAu65qVXsA9D/T+uuoRVqhE+JCyFHFrO0ixRbZDRK1XJt1sA==",
             "cpu": [
                 "wasm32"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@napi-rs/wasm-runtime": "^0.2.4"
+                "@napi-rs/wasm-runtime": "^1.0.3"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@napi-rs/lzma-win32-arm64-msvc": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-arm64-msvc/-/lzma-win32-arm64-msvc-1.4.1.tgz",
-            "integrity": "sha512-ISz+v7ML5mKnjEZ7Kk4Z1BIn411r/fz3tDy9j5yDnwQI0MgTsUQFrIQElGUpULWYs2aYc6EZ9PhECbLBfSjh7A==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-arm64-msvc/-/lzma-win32-arm64-msvc-1.4.5.tgz",
+            "integrity": "sha512-eewnqvIyyhHi3KaZtBOJXohLvwwN27gfS2G/YDWdfHlbz1jrmfeHAmzMsP5qv8vGB+T80TMHNkro4kYjeh6Deg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -1013,13 +761,14 @@
             }
         },
         "node_modules/@napi-rs/lzma-win32-ia32-msvc": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-ia32-msvc/-/lzma-win32-ia32-msvc-1.4.1.tgz",
-            "integrity": "sha512-3WKuCpZBrd7Jrw+h1jSu5XAsRWepMJu0sYuRoA4Y4Cwfu9gI7p5Z5Bc510nfjg7M7xvdpkI4UoW2WY7kBFRYrQ==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-ia32-msvc/-/lzma-win32-ia32-msvc-1.4.5.tgz",
+            "integrity": "sha512-OeacFVRCJOKNU/a0ephUfYZ2Yt+NvaHze/4TgOwJ0J0P4P7X1mHzN+ig9Iyd74aQDXYqc7kaCXA2dpAOcH87Cg==",
             "cpu": [
                 "ia32"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -1029,13 +778,14 @@
             }
         },
         "node_modules/@napi-rs/lzma-win32-x64-msvc": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-x64-msvc/-/lzma-win32-x64-msvc-1.4.1.tgz",
-            "integrity": "sha512-0ixRo5z1zFXdh62hlrTV+QCTKHK0te5NHKaExOluhtcc6AdpMmpslvM9JhUxNHI+zM46w/DmmcvcOtqsaTmHgg==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-x64-msvc/-/lzma-win32-x64-msvc-1.4.5.tgz",
+            "integrity": "sha512-T4I1SamdSmtyZgDXGAGP+y5LEK5vxHUFwe8mz6D4R7Sa5/WCxTcCIgPJ9BD7RkpO17lzhlaM2vmVvMy96Lvk9Q==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -1045,15 +795,318 @@
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.6.tgz",
-            "integrity": "sha512-z8YVS3XszxFTO73iwvFDNpQIzdMmSDTP/mB3E/ucR37V3Sx57hSExcXyMoNwaucWxnsWf4xfbZv0iZ30jr0M4Q==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "^1.3.1",
-                "@emnapi/runtime": "^1.3.1",
-                "@tybys/wasm-util": "^0.9.0"
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
+            }
+        },
+        "node_modules/@oxc-parser/binding-android-arm64": {
+            "version": "0.76.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.76.0.tgz",
+            "integrity": "sha512-1XJW/16CDmF5bHE7LAyPPmEEVnxSadDgdJz+xiLqBrmC4lfAeuAfRw3HlOygcPGr+AJsbD4Z5sFJMkwjbSZlQg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-darwin-arm64": {
+            "version": "0.76.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.76.0.tgz",
+            "integrity": "sha512-yoQwSom8xsB+JdGsPUU0xxmxLKiF2kdlrK7I56WtGKZilixuBf/TmOwNYJYLRWkBoW5l2/pDZOhBm2luwmLiLw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-darwin-x64": {
+            "version": "0.76.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.76.0.tgz",
+            "integrity": "sha512-uRIopPLvr3pf2Xj7f5LKyCuqzIU6zOS+zEIR8UDYhcgJyZHnvBkfrYnfcztyIcrGdQehrFUi3uplmI09E7RdiQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-freebsd-x64": {
+            "version": "0.76.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.76.0.tgz",
+            "integrity": "sha512-a0EOFvnOd2FqmDSvH6uWLROSlU6KV/JDKbsYDA/zRLyKcG6HCsmFnPsp8iV7/xr9WMbNgyJi6R5IMpePQlUq7Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+            "version": "0.76.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.76.0.tgz",
+            "integrity": "sha512-ikRYDHL3fOdZwfJKmcdqjlLgkeNZ3Ez0qM8wAev5zlHZ+lY/Ig7qG5SCqPlvuTu+nNQ6zrFFaKvvt69EBKXU/g==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+            "version": "0.76.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.76.0.tgz",
+            "integrity": "sha512-dtRv5J5MRCLR7x39K8ufIIW4svIc7gYFUaI0YFXmmeOBhK/K2t/CkguPnDroKtsmXIPHDRtmJ1JJYzNcgJl6Wg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+            "version": "0.76.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.76.0.tgz",
+            "integrity": "sha512-IE4iiiggFH2snagQxHrY5bv6dDpRMMat+vdlMN/ibonA65eOmRLp8VLTXnDiNrcla/itJ1L9qGABHNKU+SnE8g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+            "version": "0.76.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.76.0.tgz",
+            "integrity": "sha512-wi9zQPMDHrBuRuT7Iurfidc9qlZh7cKa5vfYzOWNBCaqJdgxmNOFzvYen02wVUxSWGKhpiPHxrPX0jdRyJ8Npg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+            "version": "0.76.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.76.0.tgz",
+            "integrity": "sha512-0tqqu1pqPee2lLGY8vtYlX1L415fFn89e0a3yp4q5N9f03j1rRs0R31qesTm3bt/UK8HYjECZ+56FCVPs2MEMQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+            "version": "0.76.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.76.0.tgz",
+            "integrity": "sha512-y36Hh1a5TA+oIGtlc8lT7N9vdHXBlhBetQJW0p457KbiVQ7jF7AZkaPWhESkjHWAsTVKD2OjCa9ZqfaqhSI0FQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+            "version": "0.76.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.76.0.tgz",
+            "integrity": "sha512-7/acaG9htovp3gp/J0kHgbItQTuHctl+rbqPPqZ9DRBYTz8iV8kv3QN8t8Or8i/hOmOjfZp9McDoSU1duoR4/A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-x64-musl": {
+            "version": "0.76.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.76.0.tgz",
+            "integrity": "sha512-AxFt0reY6Q2rfudABmMTFGR8tFFr58NlH2rRBQgcj+F+iEwgJ+jMwAPhXd2y1I2zaI8GspuahedUYQinqxWqjA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-wasm32-wasi": {
+            "version": "0.76.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.76.0.tgz",
+            "integrity": "sha512-wHdkHdhf6AWBoO8vs5cpoR6zEFY1rB+fXWtq6j/xb9j/lu1evlujRVMkh8IM/M/pOUIrNkna3nzST/mRImiveQ==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "^0.2.11"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+            "version": "0.2.12",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+            "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.4.3",
+                "@emnapi/runtime": "^1.4.3",
+                "@tybys/wasm-util": "^0.10.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+            "version": "0.76.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.76.0.tgz",
+            "integrity": "sha512-G7ZlEWcb2hNwCK3qalzqJoyB6HaTigQ/GEa7CU8sAJ/WwMdG/NnPqiC9IqpEAEy1ARSo4XMALfKbKNuqbSs5mg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+            "version": "0.76.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.76.0.tgz",
+            "integrity": "sha512-0jLzzmnu8/mqNhKBnNS2lFUbPEzRdj5ReiZwHGHpjma0+ullmmwP2AqSEqx3ssHDK9CpcEMdKOK2LsbCfhHKIA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-project/types": {
+            "version": "0.127.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+            "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
             }
         },
         "node_modules/@playwright/test": {
@@ -1071,6 +1124,288 @@
             "engines": {
                 "node": ">=18"
             }
+        },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+            "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+            "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+            "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+            "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.10.0",
+                "@emnapi/runtime": "1.10.0",
+                "@napi-rs/wasm-runtime": "^1.1.4"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+            "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+            "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+            "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@rollup/plugin-commonjs": {
             "version": "28.0.6",
@@ -1145,10 +1480,11 @@
             }
         },
         "node_modules/@rollup/plugin-typescript": {
-            "version": "12.1.4",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-12.1.4.tgz",
-            "integrity": "sha512-s5Hx+EtN60LMlDBvl5f04bEiFZmAepk27Q+mr85L/00zPDn1jtzlTV6FWn81MaIwqfWzKxmOJrBWHU6vtQyedQ==",
+            "version": "12.3.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-12.3.0.tgz",
+            "integrity": "sha512-7DP0/p7y3t67+NabT9f8oTBFE6gGkto4SA6Np2oudYmZE/m1dt8RB0SjL1msMxFpLo631qjRCcBlAbq1ml/Big==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@rollup/pluginutils": "^5.1.0",
                 "resolve": "^1.22.1"
@@ -1553,30 +1889,41 @@
             "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
             "dev": true
         },
-        "node_modules/@tybys/wasm-util": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
-            "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+            "dev": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@types/chai": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
-            "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@types/deep-eql": "*"
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
             }
         },
         "node_modules/@types/deep-eql": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
             "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/estree": {
             "version": "1.0.8",
@@ -1594,13 +1941,13 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "24.1.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
-            "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+            "version": "24.12.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+            "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~7.8.0"
+                "undici-types": "~7.16.0"
             }
         },
         "node_modules/@types/resolve": {
@@ -1617,37 +1964,40 @@
             "dev": true
         },
         "node_modules/@vitest/expect": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-            "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+            "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "3.2.4",
-                "@vitest/utils": "3.2.4",
-                "chai": "^5.2.0",
-                "tinyrainbow": "^2.0.0"
+                "@vitest/spy": "4.1.5",
+                "@vitest/utils": "4.1.5",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-            "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+            "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "3.2.4",
+                "@vitest/spy": "4.1.5",
                 "estree-walker": "^3.0.3",
-                "magic-string": "^0.30.17"
+                "magic-string": "^0.30.21"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
                 "msw": "^2.4.9",
-                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
             },
             "peerDependenciesMeta": {
                 "msw": {
@@ -1663,44 +2013,48 @@
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
             "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0"
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-            "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+            "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "tinyrainbow": "^2.0.0"
+                "tinyrainbow": "^3.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-            "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+            "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "3.2.4",
-                "pathe": "^2.0.3",
-                "strip-literal": "^3.0.0"
+                "@vitest/utils": "4.1.5",
+                "pathe": "^2.0.3"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-            "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+            "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "3.2.4",
-                "magic-string": "^0.30.17",
+                "@vitest/pretty-format": "4.1.5",
+                "@vitest/utils": "4.1.5",
+                "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
             },
             "funding": {
@@ -1708,26 +2062,25 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-            "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+            "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
             "dev": true,
-            "dependencies": {
-                "tinyspy": "^4.0.3"
-            },
+            "license": "MIT",
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-            "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+            "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "3.2.4",
-                "loupe": "^3.1.4",
-                "tinyrainbow": "^2.0.0"
+                "@vitest/pretty-format": "4.1.5",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
@@ -1771,8 +2124,25 @@
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
             "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/available-typed-arrays": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "possible-typed-array-names": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/balanced-match": {
@@ -1800,7 +2170,8 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/binaryen": {
             "version": "118.0.0",
@@ -1824,6 +2195,7 @@
             "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
             "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "readable-stream": "^2.3.5",
                 "safe-buffer": "^5.1.1"
@@ -1858,6 +2230,7 @@
                     "url": "https://feross.org/support"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
@@ -1868,6 +2241,7 @@
             "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
             "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "buffer-alloc-unsafe": "^1.1.0",
                 "buffer-fill": "^1.0.0"
@@ -1877,13 +2251,15 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
             "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/buffer-crc32": {
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
             "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "*"
             }
@@ -1892,7 +2268,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
             "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
@@ -1901,29 +2278,64 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/cac": {
-            "version": "6.7.14",
-            "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-            "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+        "node_modules/call-bind": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+            "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
             "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "get-intrinsic": "^1.3.0",
+                "set-function-length": "^1.2.2"
+            },
             "engines": {
-                "node": ">=8"
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/chai": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
-            "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
             "dev": true,
-            "dependencies": {
-                "assertion-error": "^2.0.1",
-                "check-error": "^2.1.1",
-                "deep-eql": "^5.0.1",
-                "loupe": "^3.1.0",
-                "pathval": "^2.0.0"
-            },
+            "license": "MIT",
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/chalk": {
@@ -1953,15 +2365,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk-template?sponsor=1"
-            }
-        },
-        "node_modules/check-error": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-            "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
-            "dev": true,
-            "engines": {
-                "node": ">= 16"
             }
         },
         "node_modules/cli-cursor": {
@@ -2010,34 +2413,26 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/core-util-is": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-            "dev": true
-        },
-        "node_modules/debug": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
             "dev": true,
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
+            "license": "MIT"
         },
         "node_modules/decompress": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
             "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "decompress-tar": "^4.0.0",
                 "decompress-tarbz2": "^4.0.0",
@@ -2057,6 +2452,7 @@
             "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
             "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "file-type": "^5.2.0",
                 "is-stream": "^1.1.0",
@@ -2071,6 +2467,7 @@
             "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
             "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "decompress-tar": "^4.1.0",
                 "file-type": "^6.1.0",
@@ -2087,6 +2484,7 @@
             "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
             "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
@@ -2096,6 +2494,7 @@
             "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
             "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "decompress-tar": "^4.1.1",
                 "file-type": "^5.2.0",
@@ -2110,6 +2509,7 @@
             "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
             "integrity": "sha512-1fqeluvxgnn86MOh66u8FjbtJpAFv5wgCT9Iw8rcBqQcCo5tO8eiJw7NNTrvt9n4CRBVq7CstiS922oPgyGLrw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "file-type": "^3.8.0",
                 "get-stream": "^2.2.0",
@@ -2125,17 +2525,9 @@
             "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
             "integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/deep-eql": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-            "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/deepmerge": {
@@ -2148,6 +2540,49 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/define-data-property": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/emoji-regex": {
             "version": "10.4.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
@@ -2156,10 +2591,11 @@
             "license": "MIT"
         },
         "node_modules/end-of-stream": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "once": "^1.4.0"
             }
@@ -2177,51 +2613,44 @@
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/es-module-lexer": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+            "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/esbuild": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
-            "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
             "dev": true,
-            "hasInstallScript": true,
-            "bin": {
-                "esbuild": "bin/esbuild"
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
             },
             "engines": {
-                "node": ">=18"
-            },
-            "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.25.5",
-                "@esbuild/android-arm": "0.25.5",
-                "@esbuild/android-arm64": "0.25.5",
-                "@esbuild/android-x64": "0.25.5",
-                "@esbuild/darwin-arm64": "0.25.5",
-                "@esbuild/darwin-x64": "0.25.5",
-                "@esbuild/freebsd-arm64": "0.25.5",
-                "@esbuild/freebsd-x64": "0.25.5",
-                "@esbuild/linux-arm": "0.25.5",
-                "@esbuild/linux-arm64": "0.25.5",
-                "@esbuild/linux-ia32": "0.25.5",
-                "@esbuild/linux-loong64": "0.25.5",
-                "@esbuild/linux-mips64el": "0.25.5",
-                "@esbuild/linux-ppc64": "0.25.5",
-                "@esbuild/linux-riscv64": "0.25.5",
-                "@esbuild/linux-s390x": "0.25.5",
-                "@esbuild/linux-x64": "0.25.5",
-                "@esbuild/netbsd-arm64": "0.25.5",
-                "@esbuild/netbsd-x64": "0.25.5",
-                "@esbuild/openbsd-arm64": "0.25.5",
-                "@esbuild/openbsd-x64": "0.25.5",
-                "@esbuild/sunos-x64": "0.25.5",
-                "@esbuild/win32-arm64": "0.25.5",
-                "@esbuild/win32-ia32": "0.25.5",
-                "@esbuild/win32-x64": "0.25.5"
+                "node": ">= 0.4"
             }
         },
         "node_modules/estree-walker": {
@@ -2232,9 +2661,9 @@
             "license": "MIT"
         },
         "node_modules/expect-type": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
-            "integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -2246,15 +2675,20 @@
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
             "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "pend": "~1.2.0"
             }
         },
         "node_modules/fdir": {
-            "version": "6.4.6",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-            "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
             "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
             "peerDependencies": {
                 "picomatch": "^3 || ^4"
             },
@@ -2269,15 +2703,33 @@
             "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
             "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/for-each": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+            "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-callable": "^1.2.7"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/fs-constants": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/fsevents": {
             "version": "2.3.2",
@@ -2317,11 +2769,51 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/get-stream": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
             "integrity": "sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "object-assign": "^4.0.1",
                 "pinkie-promise": "^2.0.0"
@@ -2330,11 +2822,67 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/has-property-descriptors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/hasown": {
             "version": "2.0.2",
@@ -2367,13 +2915,28 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ]
+            ],
+            "license": "BSD-3-Clause"
         },
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/is-callable": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/is-core-module": {
             "version": "2.16.0",
@@ -2415,7 +2978,8 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
             "integrity": "sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/is-reference": {
             "version": "1.2.1",
@@ -2432,8 +2996,25 @@
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-typed-array": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "which-typed-array": "^1.1.16"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-unicode-supported": {
@@ -2453,13 +3034,281 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
-        "node_modules/js-tokens": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-            "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-            "dev": true
+        "node_modules/lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
         },
         "node_modules/linkify-it": {
             "version": "5.0.0",
@@ -2501,12 +3350,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/loupe": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.4.tgz",
-            "integrity": "sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==",
-            "dev": true
-        },
         "node_modules/lunr": {
             "version": "2.3.9",
             "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
@@ -2515,13 +3358,13 @@
             "license": "MIT"
         },
         "node_modules/magic-string": {
-            "version": "0.30.17",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-            "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.5.0"
+                "@jridgewell/sourcemap-codec": "^1.5.5"
             }
         },
         "node_modules/make-dir": {
@@ -2529,6 +3372,7 @@
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
             "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "pify": "^3.0.0"
             },
@@ -2541,6 +3385,7 @@
             "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
             "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
@@ -2561,6 +3406,16 @@
             },
             "bin": {
                 "markdown-it": "bin/markdown-it.mjs"
+            }
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/mdurl": {
@@ -2615,16 +3470,10 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true
-        },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.12",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
             "dev": true,
             "funding": [
                 {
@@ -2632,6 +3481,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -2644,15 +3494,28 @@
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/obug": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+            "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT"
         },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
             }
@@ -2697,6 +3560,49 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/oxc-parser": {
+            "version": "0.76.0",
+            "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.76.0.tgz",
+            "integrity": "sha512-l98B2e9evuhES7zN99rb1QGhbzx25829TJFaKi2j0ib3/K/G5z1FdGYz6HZkrU3U8jdH7v2FC8mX1j2l9JrOUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "^0.76.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            },
+            "optionalDependencies": {
+                "@oxc-parser/binding-android-arm64": "0.76.0",
+                "@oxc-parser/binding-darwin-arm64": "0.76.0",
+                "@oxc-parser/binding-darwin-x64": "0.76.0",
+                "@oxc-parser/binding-freebsd-x64": "0.76.0",
+                "@oxc-parser/binding-linux-arm-gnueabihf": "0.76.0",
+                "@oxc-parser/binding-linux-arm-musleabihf": "0.76.0",
+                "@oxc-parser/binding-linux-arm64-gnu": "0.76.0",
+                "@oxc-parser/binding-linux-arm64-musl": "0.76.0",
+                "@oxc-parser/binding-linux-riscv64-gnu": "0.76.0",
+                "@oxc-parser/binding-linux-s390x-gnu": "0.76.0",
+                "@oxc-parser/binding-linux-x64-gnu": "0.76.0",
+                "@oxc-parser/binding-linux-x64-musl": "0.76.0",
+                "@oxc-parser/binding-wasm32-wasi": "0.76.0",
+                "@oxc-parser/binding-win32-arm64-msvc": "0.76.0",
+                "@oxc-parser/binding-win32-x64-msvc": "0.76.0"
+            }
+        },
+        "node_modules/oxc-parser/node_modules/@oxc-project/types": {
+            "version": "0.76.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.76.0.tgz",
+            "integrity": "sha512-CH3THIrSViKal8yV/Wh3FK0pFhp40nzW1MUDCik9fNuid2D/7JJXKJnfFOAvMxInGXDlvmgT6ACAzrl47TqzkQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
         "node_modules/path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -2708,33 +3614,27 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
             "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "dev": true
-        },
-        "node_modules/pathval": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-            "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
             "dev": true,
-            "engines": {
-                "node": ">= 14.16"
-            }
+            "license": "MIT"
         },
         "node_modules/pend": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
             "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2749,6 +3649,7 @@
             "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
             "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2758,6 +3659,7 @@
             "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
             "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2767,6 +3669,7 @@
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "pinkie": "^2.0.0"
             },
@@ -2806,10 +3709,20 @@
                 "node": ">=18"
             }
         },
+        "node_modules/possible-typed-array-names": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+            "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "version": "8.5.14",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
             "dev": true,
             "funding": [
                 {
@@ -2825,6 +3738,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -2835,10 +3749,11 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-            "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+            "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -2853,7 +3768,8 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/punycode.js": {
             "version": "2.3.1",
@@ -2870,6 +3786,7 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
             "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -2884,7 +3801,8 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/resolve": {
             "version": "1.22.9",
@@ -2919,6 +3837,40 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/rolldown": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+            "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "=0.127.0",
+                "@rolldown/pluginutils": "1.0.0-rc.17"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
             }
         },
         "node_modules/rollup": {
@@ -2979,13 +3931,15 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/seek-bzip": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
             "integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "commander": "^2.8.1"
             },
@@ -2998,7 +3952,26 @@
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/set-function-length": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/siginfo": {
             "version": "2.0.0",
@@ -3035,6 +4008,7 @@
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3058,9 +4032,9 @@
             "license": "MIT"
         },
         "node_modules/std-env": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
-            "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+            "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -3082,6 +4056,7 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
@@ -3090,7 +4065,8 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/string-width": {
             "version": "7.2.0",
@@ -3131,20 +4107,9 @@
             "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
             "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "is-natural-number": "^4.0.1"
-            }
-        },
-        "node_modules/strip-literal": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
-            "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
-            "dev": true,
-            "dependencies": {
-                "js-tokens": "^9.0.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/supports-preserve-symlinks-flag": {
@@ -3165,6 +4130,7 @@
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
             "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "bl": "^1.0.0",
                 "buffer-alloc": "^1.2.0",
@@ -3208,7 +4174,8 @@
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/tinybench": {
             "version": "2.9.0",
@@ -3218,20 +4185,24 @@
             "license": "MIT"
         },
         "node_modules/tinyexec": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-            "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+            "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -3240,44 +4211,58 @@
                 "url": "https://github.com/sponsors/SuperchupuDev"
             }
         },
-        "node_modules/tinypool": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-            "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-            "dev": true,
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            }
-        },
         "node_modules/tinyrainbow": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-            "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
             "dev": true,
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/tinyspy": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
-            "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
-            "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/to-buffer": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-            "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-            "dev": true
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+            "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "isarray": "^2.0.5",
+                "safe-buffer": "^5.2.1",
+                "typed-array-buffer": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/to-buffer/node_modules/isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD"
+        },
+        "node_modules/typed-array-buffer": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+            "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "is-typed-array": "^1.1.14"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/typedoc": {
             "version": "0.28.8",
@@ -3330,35 +4315,38 @@
             "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
             "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "buffer": "^5.2.1",
                 "through": "^2.3.8"
             }
         },
         "node_modules/undici-types": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-            "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-            "dev": true
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+            "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/vite": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.0.tgz",
-            "integrity": "sha512-ixXJB1YRgDIw2OszKQS9WxGHKwLdCsbQNkpJN171udl6szi/rIySHL6/Os3s2+oE4P/FLD4dxg4mD7Wust+u5g==",
+            "version": "8.0.10",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+            "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "esbuild": "^0.25.0",
-                "fdir": "^6.4.6",
-                "picomatch": "^4.0.2",
-                "postcss": "^8.5.6",
-                "rollup": "^4.40.0",
-                "tinyglobby": "^0.2.14"
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.4",
+                "postcss": "^8.5.10",
+                "rolldown": "1.0.0-rc.17",
+                "tinyglobby": "^0.2.16"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -3374,9 +4362,10 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.1.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
-                "lightningcss": "^1.21.0",
                 "sass": "^1.70.0",
                 "sass-embedded": "^1.70.0",
                 "stylus": ">=0.54.8",
@@ -3389,13 +4378,16 @@
                 "@types/node": {
                     "optional": true
                 },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
                 "jiti": {
                     "optional": true
                 },
                 "less": {
-                    "optional": true
-                },
-                "lightningcss": {
                     "optional": true
                 },
                 "sass": {
@@ -3421,34 +4413,13 @@
                 }
             }
         },
-        "node_modules/vite-node": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-            "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-            "dev": true,
-            "dependencies": {
-                "cac": "^6.7.14",
-                "debug": "^4.4.1",
-                "es-module-lexer": "^1.7.0",
-                "pathe": "^2.0.3",
-                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-            },
-            "bin": {
-                "vite-node": "vite-node.mjs"
-            },
-            "engines": {
-                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            }
-        },
         "node_modules/vite/node_modules/fsevents": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
             "dev": true,
             "hasInstallScript": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -3458,64 +4429,79 @@
             }
         },
         "node_modules/vitest": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-            "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+            "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@types/chai": "^5.2.2",
-                "@vitest/expect": "3.2.4",
-                "@vitest/mocker": "3.2.4",
-                "@vitest/pretty-format": "^3.2.4",
-                "@vitest/runner": "3.2.4",
-                "@vitest/snapshot": "3.2.4",
-                "@vitest/spy": "3.2.4",
-                "@vitest/utils": "3.2.4",
-                "chai": "^5.2.0",
-                "debug": "^4.4.1",
-                "expect-type": "^1.2.1",
-                "magic-string": "^0.30.17",
+                "@vitest/expect": "4.1.5",
+                "@vitest/mocker": "4.1.5",
+                "@vitest/pretty-format": "4.1.5",
+                "@vitest/runner": "4.1.5",
+                "@vitest/snapshot": "4.1.5",
+                "@vitest/spy": "4.1.5",
+                "@vitest/utils": "4.1.5",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
                 "pathe": "^2.0.3",
-                "picomatch": "^4.0.2",
-                "std-env": "^3.9.0",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
                 "tinybench": "^2.9.0",
-                "tinyexec": "^0.3.2",
-                "tinyglobby": "^0.2.14",
-                "tinypool": "^1.1.1",
-                "tinyrainbow": "^2.0.0",
-                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-                "vite-node": "3.2.4",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
                 "why-is-node-running": "^2.3.0"
             },
             "bin": {
                 "vitest": "vitest.mjs"
             },
             "engines": {
-                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
                 "@edge-runtime/vm": "*",
-                "@types/debug": "^4.1.12",
-                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-                "@vitest/browser": "3.2.4",
-                "@vitest/ui": "3.2.4",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.5",
+                "@vitest/browser-preview": "4.1.5",
+                "@vitest/browser-webdriverio": "4.1.5",
+                "@vitest/coverage-istanbul": "4.1.5",
+                "@vitest/coverage-v8": "4.1.5",
+                "@vitest/ui": "4.1.5",
                 "happy-dom": "*",
-                "jsdom": "*"
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
             },
             "peerDependenciesMeta": {
                 "@edge-runtime/vm": {
                     "optional": true
                 },
-                "@types/debug": {
+                "@opentelemetry/api": {
                     "optional": true
                 },
                 "@types/node": {
                     "optional": true
                 },
-                "@vitest/browser": {
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
                     "optional": true
                 },
                 "@vitest/ui": {
@@ -3526,7 +4512,32 @@
                 },
                 "jsdom": {
                     "optional": true
+                },
+                "vite": {
+                    "optional": false
                 }
+            }
+        },
+        "node_modules/which-typed-array": {
+            "version": "1.1.20",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+            "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "for-each": "^0.3.5",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/why-is-node-running": {
@@ -3550,13 +4561,15 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/xtend": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
             "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.4"
             }
@@ -3579,6 +4592,7 @@
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
             "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "buffer-crc32": "~0.2.3",
                 "fd-slicer": "~1.1.0"
@@ -3655,25 +4669,26 @@
                 "tslib": "^2.8.1"
             },
             "devDependencies": {
-                "@bytecodealliance/jco": "1.8.1",
-                "@rollup/plugin-typescript": "^12.1.4",
-                "@types/node": "24.1.0",
-                "prettier": "^3.6.2",
-                "typescript": "^5.9.2",
-                "vitest": "^3.2.4"
+                "@bytecodealliance/jco": "^1.19.0",
+                "@rollup/plugin-typescript": "^12.3.0",
+                "@types/node": "^24.12.2",
+                "prettier": "^3.8.3",
+                "typescript": "^5.9.3",
+                "vitest": "^4.1.5"
             }
         },
         "packages/npm-packages/ruby-wasm-wasi/node_modules/@bytecodealliance/jco": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-1.8.1.tgz",
-            "integrity": "sha512-mYjE7lrSWEzFD6lAVA4skm9/6DvorFjuO5DHoxzwWlJ2hKyO/d9t0Wx1V0nT5L1s7+98ZtVSB1emYLNMebpMdA==",
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-1.19.0.tgz",
+            "integrity": "sha512-I57cVbL24/u/zCBwHq7D9PyIMP81hFFYF4hL/pW5biRGVLQAZuwEAUaEmghOouyt77bU2ExqscP2wkLvr3nfDw==",
             "dev": true,
+            "license": "(Apache-2.0 WITH LLVM-exception)",
             "dependencies": {
-                "@bytecodealliance/componentize-js": "^0.14.0",
-                "@bytecodealliance/preview2-shim": "^0.17.1",
-                "binaryen": "^120.0.0",
-                "chalk-template": "^1",
-                "commander": "^12",
+                "@bytecodealliance/componentize-js": "^0.20.0",
+                "@bytecodealliance/componentize-js-0-19-3": "npm:@bytecodealliance/componentize-js@^0.19.3",
+                "@bytecodealliance/preview2-shim": "^0.17.9",
+                "binaryen": "^123.0.0",
+                "commander": "^14",
                 "mkdirp": "^3",
                 "ora": "^8",
                 "terser": "^5"
@@ -3683,10 +4698,11 @@
             }
         },
         "packages/npm-packages/ruby-wasm-wasi/node_modules/binaryen": {
-            "version": "120.0.0",
-            "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-120.0.0.tgz",
-            "integrity": "sha512-MaNC1qW5ubk5S7MNNxNpAb9ivKp6TAf8CDknRk4XeCC2wkrpdaubK10S1CAwUXaDDF54gZLtk6opzbEA9VTtJw==",
+            "version": "123.0.0",
+            "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-123.0.0.tgz",
+            "integrity": "sha512-/hls/a309aZCc0itqP6uhoR+5DsKSlJVfB8Opd2BY9Ndghs84IScTunlyidyF4r2Xe3lQttnfBNIDjaNpj6mTw==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "wasm-as": "bin/wasm-as",
                 "wasm-ctor-eval": "bin/wasm-ctor-eval",
@@ -3699,10 +4715,20 @@
                 "wasm2js": "bin/wasm2js"
             }
         },
+        "packages/npm-packages/ruby-wasm-wasi/node_modules/commander": {
+            "version": "14.0.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+            "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "packages/npm-packages/ruby-wasm-wasi/node_modules/typescript": {
-            "version": "5.9.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-            "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/packages/npm-packages/ruby-wasm-wasi/package.json
+++ b/packages/npm-packages/ruby-wasm-wasi/package.json
@@ -53,12 +53,12 @@
     "build": "npm run build:rollup && npm run build:tsc && npm run build:static && ./tools/post-build.sh ./dist"
   },
   "devDependencies": {
-    "@bytecodealliance/jco": "1.8.1",
-    "@rollup/plugin-typescript": "^12.1.4",
-    "@types/node": "24.1.0",
-    "prettier": "^3.6.2",
-    "typescript": "^5.9.2",
-    "vitest": "^3.2.4"
+    "@bytecodealliance/jco": "^1.19.0",
+    "@rollup/plugin-typescript": "^12.3.0",
+    "@types/node": "^24.12.2",
+    "prettier": "^3.8.3",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.5"
   },
   "dependencies": {
     "@bjorn3/browser_wasi_shim": "^0.4.2",

--- a/packages/npm-packages/ruby-wasm-wasi/rollup.config.mjs
+++ b/packages/npm-packages/ruby-wasm-wasi/rollup.config.mjs
@@ -1,7 +1,11 @@
 import typescript from "@rollup/plugin-typescript";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 
-const typescriptOptions = { tsconfig: "./tsconfig.json", declaration: false };
+const typescriptOptions = {
+  tsconfig: "./tsconfig.json",
+  declaration: false,
+  outDir: "./dist",
+};
 
 function config({ basename }) {
   return {

--- a/packages/npm-packages/ruby-wasm-wasi/src/bindgen/interfaces/ruby-js-js-runtime.d.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/bindgen/interfaces/ruby-js-js-runtime.d.ts
@@ -1,27 +1,25 @@
-export namespace RubyJsJsRuntime {
-  export function evalJs(code: string): JsAbiResult;
-  export function isJs(value: JsAbiValue): boolean;
-  export function instanceOf(value: JsAbiValue, klass: JsAbiValue): boolean;
-  export function globalThis(): JsAbiValue;
-  export function intToJsNumber(value: number): JsAbiValue;
-  export function floatToJsNumber(value: number): JsAbiValue;
-  export function stringToJsString(value: string): JsAbiValue;
-  export function boolToJsBool(value: boolean): JsAbiValue;
-  export function procToJsFunction(): JsAbiValue;
-  export function rbObjectToJsRbValue(): JsAbiValue;
-  export function jsValueToString(value: JsAbiValue): string;
-  export function jsValueToInteger(value: JsAbiValue): RawInteger;
-  export function exportJsValueToHost(value: JsAbiValue): void;
-  export function importJsValueFromHost(): JsAbiValue;
-  export function jsValueTypeof(value: JsAbiValue): string;
-  export function jsValueEqual(lhs: JsAbiValue, rhs: JsAbiValue): boolean;
-  export function jsValueStrictlyEqual(lhs: JsAbiValue, rhs: JsAbiValue): boolean;
-  export function reflectApply(target: JsAbiValue, thisArgument: JsAbiValue, arguments: Array<JsAbiValue>): JsAbiResult;
-  export function reflectGet(target: JsAbiValue, propertyKey: string): JsAbiResult;
-  export function reflectSet(target: JsAbiValue, propertyKey: string, value: JsAbiValue): JsAbiResult;
-  export function throwProhibitRewindException(message: string): void;
-  export { JsAbiValue };
-}
+/** @module Interface ruby:js/js-runtime **/
+export function evalJs(code: string): JsAbiResult;
+export function isJs(value: JsAbiValue): boolean;
+export function instanceOf(value: JsAbiValue, klass: JsAbiValue): boolean;
+export function globalThis(): JsAbiValue;
+export function intToJsNumber(value: number): JsAbiValue;
+export function floatToJsNumber(value: number): JsAbiValue;
+export function stringToJsString(value: string): JsAbiValue;
+export function boolToJsBool(value: boolean): JsAbiValue;
+export function procToJsFunction(): JsAbiValue;
+export function rbObjectToJsRbValue(): JsAbiValue;
+export function jsValueToString(value: JsAbiValue): string;
+export function jsValueToInteger(value: JsAbiValue): RawInteger;
+export function exportJsValueToHost(value: JsAbiValue): void;
+export function importJsValueFromHost(): JsAbiValue;
+export function jsValueTypeof(value: JsAbiValue): string;
+export function jsValueEqual(lhs: JsAbiValue, rhs: JsAbiValue): boolean;
+export function jsValueStrictlyEqual(lhs: JsAbiValue, rhs: JsAbiValue): boolean;
+export function reflectApply(target: JsAbiValue, thisArgument: JsAbiValue, arguments: Array<JsAbiValue>): JsAbiResult;
+export function reflectGet(target: JsAbiValue, propertyKey: string): JsAbiResult;
+export function reflectSet(target: JsAbiValue, propertyKey: string, value: JsAbiValue): JsAbiResult;
+export function throwProhibitRewindException(message: string): void;
 export type JsAbiResult = JsAbiResultSuccess | JsAbiResultFailure;
 export interface JsAbiResultSuccess {
   tag: 'success',
@@ -42,4 +40,8 @@ export interface RawIntegerBignum {
 }
 
 export class JsAbiValue {
+  /**
+   * This type does not have a public constructor.
+   */
+  private constructor();
 }

--- a/packages/npm-packages/ruby-wasm-wasi/src/bindgen/interfaces/ruby-js-ruby-runtime.d.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/bindgen/interfaces/ruby-js-ruby-runtime.d.ts
@@ -1,35 +1,36 @@
-export namespace RubyJsRubyRuntime {
-  export function rubyShowVersion(): void;
-  export function rubyInit(args: Array<string>): void;
-  export function rubyInitLoadpath(): void;
-  export function rbEvalStringProtect(str: string): [RbAbiValue, number];
-  export function rbFuncallvProtect(recv: RbAbiValue, mid: RbId, args: Array<RbAbiValue>): [RbAbiValue, number];
-  export function rbIntern(name: string): RbId;
-  export function rbErrinfo(): RbAbiValue;
-  export function rbClearErrinfo(): void;
-  export function rstringPtr(value: RbAbiValue): string;
-  export function rbVmBugreport(): void;
-  export function rbGcEnable(): boolean;
-  export function rbGcDisable(): boolean;
-  export function rbSetShouldProhibitRewind(newValue: boolean): boolean;
-  /**
-   * XXX: Do we really need them?
-   * wrap-js-value: func(value: js-abi-value) -> rb-abi-value;
-   * to-js-value: func(value: borrow<rb-abi-value>) -> js-abi-value;
-   * Transfer the value from Ruby to JS
-   * 
-   * 1. Ruby side registers the value in the stage
-   * 2. Ruby side calls JS's `import-rb-value-from-rb()`
-   * 3. `import-rb-value-from-rb()` calls `export-rb-value-to-js()`
-   * 4. `export-rb-value-to-js()` returns the staged value
-   */
-  export function exportRbValueToJs(): RbAbiValue;
-  export { RbAbiValue };
-}
-import type { JsAbiValue } from './ruby-js-js-runtime.js';
-export { JsAbiValue };
+/** @module Interface ruby:js/ruby-runtime **/
+export function rubyShowVersion(): void;
+export function rubyInit(args: Array<string>): void;
+export function rubyInitLoadpath(): void;
+export function rbEvalStringProtect(str: string): [RbAbiValue, number];
+export function rbFuncallvProtect(recv: RbAbiValue, mid: RbId, args: Array<RbAbiValue>): [RbAbiValue, number];
+export function rbIntern(name: string): RbId;
+export function rbErrinfo(): RbAbiValue;
+export function rbClearErrinfo(): void;
+export function rstringPtr(value: RbAbiValue): string;
+export function rbVmBugreport(): void;
+export function rbGcEnable(): boolean;
+export function rbGcDisable(): boolean;
+export function rbSetShouldProhibitRewind(newValue: boolean): boolean;
+/**
+ * XXX: Do we really need them?
+ * wrap-js-value: func(value: js-abi-value) -> rb-abi-value;
+ * to-js-value: func(value: borrow<rb-abi-value>) -> js-abi-value;
+ * Transfer the value from Ruby to JS
+ * 
+ * 1. Ruby side registers the value in the stage
+ * 2. Ruby side calls JS's `import-rb-value-from-rb()`
+ * 3. `import-rb-value-from-rb()` calls `export-rb-value-to-js()`
+ * 4. `export-rb-value-to-js()` returns the staged value
+ */
+export function exportRbValueToJs(): RbAbiValue;
+export type JsAbiValue = import('./ruby-js-js-runtime.js').JsAbiValue;
 export type RbErrno = number;
 export type RbId = number;
 
 export class RbAbiValue {
+  /**
+   * This type does not have a public constructor.
+   */
+  private constructor();
 }

--- a/packages/npm-packages/ruby-wasm-wasi/src/binding.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/binding.ts
@@ -1,4 +1,4 @@
-import { RubyJsRubyRuntime } from "./bindgen/interfaces/ruby-js-ruby-runtime.js";
+import type * as RubyJsRubyRuntime from "./bindgen/interfaces/ruby-js-ruby-runtime.js";
 import * as RbAbi from "./bindgen/legacy/rb-abi-guest.js";
 
 /**

--- a/packages/npm-packages/ruby-wasm-wasi/src/vm.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/vm.ts
@@ -1,5 +1,5 @@
-import type { RubyJsJsRuntime } from "./bindgen/interfaces/ruby-js-js-runtime.js";
-import type { RubyJsRubyRuntime } from "./bindgen/interfaces/ruby-js-ruby-runtime.js";
+import type * as RubyJsJsRuntime from "./bindgen/interfaces/ruby-js-js-runtime.js";
+import type * as RubyJsRubyRuntime from "./bindgen/interfaces/ruby-js-ruby-runtime.js";
 import * as RbAbi from "./bindgen/legacy/rb-abi-guest.js";
 import {
   RbJsAbiHost,

--- a/packages/npm-packages/ruby-wasm-wasi/vitest.config.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/vitest.config.ts
@@ -3,11 +3,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     pool: "forks",
-    poolOptions: {
-      forks: {
-        execArgv: ["--experimental-wasi-unstable-preview1", "--expose-gc"],
-      }
-    },
+    execArgv: ["--expose-gc"],
     testTimeout: 300000,
     exclude: [],
   },


### PR DESCRIPTION
## Summary

Update the `@ruby/wasm-wasi` development dependency set and refresh the lockfile.

This includes:

- updating `@bytecodealliance/jco`, `@rollup/plugin-typescript`, `@types/node`, `prettier`, `typescript`, and `vitest`
- refreshing generated WIT TypeScript declarations for the newer `jco` output format
- adjusting the local TypeScript imports to match the regenerated declarations
- updating Rollup and Vitest configuration for the newer tool versions


## Notes

I have kept TypeScript at the latest 5.9.x release. TypeScript 6 generates numerous type errors for existing code.

## About Failed Jobs

The failing jobs appear unrelated to this dependency update.

The observed failures happen while building Docker builder images, before the package build/test steps for this PR run. One failure downloads `wasi-preset-args` from a GitHub Release asset and then fails to unzip it because the downloaded file is not a valid zip. Another failure is in the NodeSource apt setup path.

This PR only changes the `@ruby/wasm-wasi` npm dev dependencies, generated WIT typings, and the Rollup/Vitest config needed for those updates. Local validation passed:

- `node packages/npm-packages/ruby-wasm-wasi/tools/component-ts-bindgen.mjs`
- `npm -C packages/npm-packages/ruby-wasm-wasi run build`
- `RUBY_NPM_PACKAGE_ROOT=../ruby-head-wasm-wasi npm -C packages/npm-packages/ruby-wasm-wasi run test:vitest -- --run`
- `RUBY_NPM_PACKAGE_ROOT=../ruby-head-wasm-wasi npm -C packages/npm-packages/ruby-wasm-wasi run test:unit`

A rerun of the failed jobs is likely the next step, but I do not have permission to trigger it.
