### PR TITLE
Enable easy passing of environment variables in `browser.script.iffe.js`

### DIFF
--- a/docs/cheat_sheet.md
+++ b/docs/cheat_sheet.md
@@ -51,9 +51,11 @@ Use `data-env` on the `browser.script.iife.js` script tag to pass environment va
 ```html
 <script
   src="https://cdn.jsdelivr.net/npm/@ruby/4.0-wasm-wasi@2.9.3-2.9.4/dist/browser.script.iife.js"
-  data-env="RUBY_BOX=1 RUBY_FIBER_MACHINE_STACK_SIZE=1048576"
+  data-env='{"RUBY_BOX":"1","RUBY_FIBER_MACHINE_STACK_SIZE":"1048576"}'
 ></script>
 ```
+
+The `data-env` value must be a JSON object string whose values are strings.
 
 If you want to control Ruby VM from JavaScript, you can use `@ruby/wasm-wasi` package API:
 

--- a/docs/cheat_sheet.md
+++ b/docs/cheat_sheet.md
@@ -46,6 +46,15 @@ The easiest way to run Ruby on browser is to use `browser.script.iife.js` script
 </html>
 ```
 
+Use `data-env` on the `browser.script.iife.js` script tag to pass environment variables when the Ruby VM starts:
+
+```html
+<script
+  src="https://cdn.jsdelivr.net/npm/@ruby/4.0-wasm-wasi@2.9.3-2.9.4/dist/browser.script.iife.js"
+  data-env="RUBY_BOX=1 RUBY_FIBER_MACHINE_STACK_SIZE=1048576"
+></script>
+```
+
 If you want to control Ruby VM from JavaScript, you can use `@ruby/wasm-wasi` package API:
 
 ```html

--- a/packages/npm-packages/ruby-wasm-wasi/example/README.md
+++ b/packages/npm-packages/ruby-wasm-wasi/example/README.md
@@ -8,6 +8,7 @@ This is a simple example of how to use the `ruby-wasm-wasi` family packages
 $ ruby -run -e httpd . -p 8000
 $ # Open http://localhost:8000/hello.html
 $ # Open http://localhost:8000/lucky.html
+$ # Open http://localhost:8000/ruby-box.html
 $ # Open http://localhost:8000/script-src
 ```
 

--- a/packages/npm-packages/ruby-wasm-wasi/example/ruby-box.html
+++ b/packages/npm-packages/ruby-wasm-wasi/example/ruby-box.html
@@ -1,0 +1,22 @@
+<html>
+  <script
+    src="https://cdn.jsdelivr.net/npm/@ruby/head-wasm-wasi@2.9.3-2.9.4/dist/browser.script.iife.js"
+    data-env="RUBY_BOX=1"
+  ></script>
+  <div id="result">
+    <div id="enabled"></div>
+    <div id="constant"></div>
+  </div>
+  <script type="text/ruby">
+    require "js"
+
+    box = Ruby::Box.new
+    box.eval <<~RUBY
+      X = 123
+    RUBY
+
+    document = JS.global[:document]
+    document.getElementById("enabled")[:innerText] = "Ruby::Box.enabled?: #{Ruby::Box.enabled?}"
+    document.getElementById("constant")[:innerText] = "box::X: #{box::X}"
+  </script>
+</html>

--- a/packages/npm-packages/ruby-wasm-wasi/example/ruby-box.html
+++ b/packages/npm-packages/ruby-wasm-wasi/example/ruby-box.html
@@ -1,7 +1,7 @@
 <html>
   <script
     src="https://cdn.jsdelivr.net/npm/@ruby/head-wasm-wasi@2.9.3-2.9.4/dist/browser.script.iife.js"
-    data-env="RUBY_BOX=1"
+    data-env='{"RUBY_BOX":"1"}'
   ></script>
   <div id="result">
     <div id="enabled"></div>

--- a/packages/npm-packages/ruby-wasm-wasi/src/browser.script.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/browser.script.ts
@@ -8,7 +8,7 @@ export const main = async (
   pkg: { name: string; version: string },
   options?: Parameters<typeof DefaultRubyVM>[1],
 ) => {
-  const scriptEnv = deriveEnv(document.currentScript);
+  const scriptEnv = parseDataEnv(document.currentScript);
   const response = fetch(
     `https://cdn.jsdelivr.net/npm/${pkg.name}@${pkg.version}/dist/ruby+stdlib.wasm`,
   );
@@ -34,7 +34,7 @@ export const componentMain = async (
         env?: Record<string, string> | undefined;
     }
 ) => {
-    const scriptEnv = deriveEnv(document.currentScript);
+    const scriptEnv = parseDataEnv(document.currentScript);
     const componentUrl = `https://cdn.jsdelivr.net/npm/${pkg.name}@${pkg.version}/dist/component`;
     const fetchComponentFile = (relativePath: string) => fetch(`${componentUrl}/${relativePath}`);
     const { vm } = await RubyVM.instantiateComponent({
@@ -103,7 +103,17 @@ const deriveEvalStyle = (tag: Element): "async" | "sync" => {
   return rawEvalStyle;
 };
 
-const deriveEnv = (tag: Element | null): Record<string, string> => {
+/**
+ * Parses the data-env attribute as a JSON object string, for example:
+ * data-env='{"RUBY_BOX":"1","MSG":"hello world"}'
+ *
+ * The parsed value must be a non-null object, not an array. Each key must not
+ * contain "=" or NUL, and each value must be a string.
+ *
+ * JSON is used instead of a shell-like KEY=value list so keys and values can
+ * contain spaces and values can contain "=" without custom escaping rules.
+ */
+const parseDataEnv = (tag: Element | null): Record<string, string> => {
   const rawEnv = tag?.getAttribute("data-env");
   if (!rawEnv) {
     return {};
@@ -114,21 +124,43 @@ const deriveEnv = (tag: Element | null): Record<string, string> => {
     return {};
   }
 
-  return trimmedEnv
-    .split(/\s+/)
-    .reduce<Record<string, string>>((env, entry) => {
-      const delimiterIndex = entry.indexOf("=");
-      if (delimiterIndex <= 0) {
+  let parsedEnv: unknown;
+  try {
+    parsedEnv = JSON.parse(trimmedEnv);
+  } catch (error) {
+    console.warn(`data-env must be a JSON object string. ${rawEnv} is ignored.`);
+    return {};
+  }
+
+  if (
+    typeof parsedEnv !== "object" ||
+    parsedEnv === null ||
+    Array.isArray(parsedEnv)
+  ) {
+    console.warn(`data-env must be a JSON object string. ${rawEnv} is ignored.`);
+    return {};
+  }
+
+  return Object.entries(parsedEnv).reduce<Record<string, string>>(
+    (env, [key, value]) => {
+      if (key.includes("=") || key.includes("\0")) {
         console.warn(
-          `data-env entry must be in the KEY=value format. ${entry} is ignored.`,
+          `data-env key must not contain "=" or NUL. ${key} is ignored.`,
         );
         return env;
       }
 
-      // Only the first "=" separates key and value so values can contain "=".
-      env[entry.slice(0, delimiterIndex)] = entry.slice(delimiterIndex + 1);
+      // POSIX environment values may contain arbitrary bytes, but data-env only accepts strings.
+      if (typeof value !== "string") {
+        console.warn(`data-env value for ${key} must be a string. It is ignored.`);
+        return env;
+      }
+
+      env[key] = value;
       return env;
-    }, {});
+    },
+    {},
+  );
 };
 
 const loadScriptAsync = async (

--- a/packages/npm-packages/ruby-wasm-wasi/src/browser.script.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/browser.script.ts
@@ -8,11 +8,18 @@ export const main = async (
   pkg: { name: string; version: string },
   options?: Parameters<typeof DefaultRubyVM>[1],
 ) => {
+  const scriptEnv = deriveEnv(document.currentScript);
   const response = fetch(
     `https://cdn.jsdelivr.net/npm/${pkg.name}@${pkg.version}/dist/ruby+stdlib.wasm`,
   );
   const module = await compileWebAssemblyModule(response);
-  const { vm } = await DefaultRubyVM(module, options);
+  const { vm } = await DefaultRubyVM(module, {
+    ...options,
+    env: {
+      ...scriptEnv,
+      ...options?.env,
+    },
+  });
   await mainWithRubyVM(vm);
 };
 
@@ -24,12 +31,18 @@ export const componentMain = async (
     options: {
         instantiate: RubyComponentInstantiator;
         wasip2: any;
+        env?: Record<string, string> | undefined;
     }
 ) => {
+    const scriptEnv = deriveEnv(document.currentScript);
     const componentUrl = `https://cdn.jsdelivr.net/npm/${pkg.name}@${pkg.version}/dist/component`;
     const fetchComponentFile = (relativePath: string) => fetch(`${componentUrl}/${relativePath}`);
     const { vm } = await RubyVM.instantiateComponent({
         ...options,
+        env: {
+            ...scriptEnv,
+            ...options.env,
+        },
         getCoreModule: (relativePath: string) => {
             const response = fetchComponentFile(relativePath);
             return compileWebAssemblyModule(response);
@@ -88,6 +101,34 @@ const deriveEvalStyle = (tag: Element): "async" | "sync" => {
     return "sync";
   }
   return rawEvalStyle;
+};
+
+const deriveEnv = (tag: Element | null): Record<string, string> => {
+  const rawEnv = tag?.getAttribute("data-env");
+  if (!rawEnv) {
+    return {};
+  }
+
+  const trimmedEnv = rawEnv.trim();
+  if (!trimmedEnv) {
+    return {};
+  }
+
+  return trimmedEnv
+    .split(/\s+/)
+    .reduce<Record<string, string>>((env, entry) => {
+      const delimiterIndex = entry.indexOf("=");
+      if (delimiterIndex <= 0) {
+        console.warn(
+          `data-env entry must be in the KEY=value format. ${entry} is ignored.`,
+        );
+        return env;
+      }
+
+      // Only the first "=" separates key and value so values can contain "=".
+      env[entry.slice(0, delimiterIndex)] = entry.slice(delimiterIndex + 1);
+      return env;
+    }, {});
 };
 
 const loadScriptAsync = async (

--- a/packages/npm-packages/ruby-wasm-wasi/src/vm.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/vm.ts
@@ -55,6 +55,11 @@ export type RubyInitComponentOptions = {
   wasip2: any;
 
   /**
+   * Environment variables to pass to the Ruby VM.
+   */
+  env?: Record<string, string> | undefined;
+
+  /**
    * The arguments to pass to the Ruby VM. Note that the first argument must be the Ruby program name.
    *
    * @default ["ruby.wasm", "-EUTF-8", "-e_=0"]
@@ -179,9 +184,18 @@ export class RubyVM {
       initComponent = async (jsRuntime) => {
         const { instantiate, getCoreModule, wasip2 } = options;
         const { cli, clocks, filesystem, io, random, sockets, http } = wasip2;
+        const environment = options.env ? {
+          ...cli.environment,
+          getEnvironment: () => Array.from(
+            new Map([
+              ...cli.environment.getEnvironment(),
+              ...Object.entries(options.env ?? {}),
+            ]).entries(),
+          ),
+        } : cli.environment;
         const importObject = {
           "ruby:js/js-runtime": jsRuntime,
-          "wasi:cli/environment": cli.environment,
+          "wasi:cli/environment": environment,
           "wasi:cli/exit": cli.exit,
           "wasi:cli/stderr": cli.stderr,
           "wasi:cli/stdin": cli.stdin,

--- a/packages/npm-packages/ruby-wasm-wasi/test-e2e/examples/examples.spec.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/test-e2e/examples/examples.spec.ts
@@ -10,6 +10,29 @@ import { readFileSync } from "fs";
 import http from "http";
 import https from "https";
 
+const ruby4OrLater = () => {
+  const packageName = path.basename(
+    process.env.RUBY_NPM_PACKAGE_ROOT ?? "ruby-head-wasm-wasi",
+  );
+  if (packageName.startsWith("ruby-head-")) {
+    return true;
+  }
+
+  const match = packageName.match(/^ruby-(\d+)\.(\d+)-wasm-wasi/);
+  if (!match) {
+    return false;
+  }
+
+  return Number(match[1]) >= 4;
+};
+
+const wasiPreview1 = () => {
+  const packageName = path.basename(
+    process.env.RUBY_NPM_PACKAGE_ROOT ?? "ruby-head-wasm-wasi",
+  );
+  return packageName.endsWith("-wasm-wasi");
+};
+
 test.beforeEach(async ({ context, page }) => {
   setupDebugLog(context);
   setupUncaughtExceptionRejection(page);
@@ -55,6 +78,26 @@ test("lucky.html is healthy", async ({ page }) => {
   expect(result).toMatch(/(Lucky|Unlucky)/);
 });
 
+test.describe("ruby-box.html", () => {
+  // Ruby::Box hooks require/load and copies extension libraries to a temporary
+  // file before loading them. The browser WASI Preview 2 setup does not
+  // currently provide writable /tmp, so the Ruby::Box example is limited to
+  // WASI Preview 1.
+  test.skip(
+    !ruby4OrLater() || !wasiPreview1(),
+    "Ruby::Box browser example requires Ruby 4.0 or later with WASI Preview 1. WASI Preview 2 does not currently provide writable /tmp.",
+  );
+
+  test("is healthy", async ({ page }) => {
+    await page.goto("/ruby-box.html");
+    await waitForRubyVM(page);
+    await expect(page.locator("#enabled")).toHaveText(
+      "Ruby::Box.enabled?: true",
+    );
+    await expect(page.locator("#constant")).toHaveText("box::X: 123");
+  });
+});
+
 test("script-src/index.html is healthy", async ({ page }) => {
   const messages: string[] = [];
   page.on("console", (msg) => messages.push(msg.text()));
@@ -80,7 +123,7 @@ if (process.env.RUBY_NPM_PACKAGE_ROOT) {
     await page.goto("/require_relative/index.html");
 
     await waitForRubyVM(page);
-  while (!messages.some((msg) => /Hello, world\!/.test(msg))) {
+    while (!messages.some((msg) => /Hello, world\!/.test(msg))) {
       await page.waitForEvent("console");
     }
   });

--- a/packages/npm-packages/ruby-wasm-wasi/test-e2e/integrations/data-env.spec.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/test-e2e/integrations/data-env.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "@playwright/test";
+
+import {
+  setupDebugLog,
+  setupProxy,
+  setupUncaughtExceptionRejection,
+  resolveBinding,
+} from "../support";
+
+if (!process.env.RUBY_NPM_PACKAGE_ROOT) {
+  test.skip("skip", () => {});
+} else {
+  test.beforeEach(async ({ context, page }) => {
+    setupDebugLog(context);
+    setupProxy(context);
+    setupUncaughtExceptionRejection(page);
+  });
+
+  test.describe("data-env", () => {
+    test("passes environment variables to the Ruby VM", async ({ page }) => {
+      const resolve = await resolveBinding(page, "checkResolved");
+      await page.setContent(`
+      <script
+        src="https://cdn.jsdelivr.net/npm/@ruby/head-wasm-wasi@latest/dist/browser.script.iife.js"
+        data-env="RUBY_WASM_TEST=ok RUBY_WASM_TEST_EQUALS=a=b"
+      ></script>
+      <script type="text/ruby" data-eval="async">
+      require "js"
+      JS.global.checkResolved [ENV["RUBY_WASM_TEST"], ENV["RUBY_WASM_TEST_EQUALS"]].join(",")
+      </script>
+    `);
+      expect(await resolve()).toBe("ok,a=b");
+    });
+  });
+}

--- a/packages/npm-packages/ruby-wasm-wasi/test-e2e/integrations/data-env.spec.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/test-e2e/integrations/data-env.spec.ts
@@ -22,14 +22,14 @@ if (!process.env.RUBY_NPM_PACKAGE_ROOT) {
       await page.setContent(`
       <script
         src="https://cdn.jsdelivr.net/npm/@ruby/head-wasm-wasi@latest/dist/browser.script.iife.js"
-        data-env="RUBY_WASM_TEST=ok RUBY_WASM_TEST_EQUALS=a=b"
+        data-env='{"RUBY_WASM_TEST":"ok","RUBY_WASM_TEST_EQUALS":"a=b","RUBY_WASM_TEST_SPACES":"hello world"}'
       ></script>
       <script type="text/ruby" data-eval="async">
       require "js"
-      JS.global.checkResolved [ENV["RUBY_WASM_TEST"], ENV["RUBY_WASM_TEST_EQUALS"]].join(",")
+      JS.global.checkResolved [ENV["RUBY_WASM_TEST"], ENV["RUBY_WASM_TEST_EQUALS"], ENV["RUBY_WASM_TEST_SPACES"]].join(",")
       </script>
     `);
-      expect(await resolve()).toBe("ok,a=b");
+      expect(await resolve()).toBe("ok,a=b,hello world");
     });
   });
 }


### PR DESCRIPTION
This change is intended to meet the expectations of https://github.com/ruby/ruby.wasm/issues/645#issuecomment-4364180421.

## Summary
- Add `browser.script.iife.js` support for passing Ruby VM environment variables via a `data-env` attribute
- Add a browser `Ruby::Box` example that enables `RUBY_BOX=1` through `data-env`
- Cover `data-env` and the `Ruby::Box` example with Playwright tests, and document `data-env` in the cheat sheet

## Notes
- data-env:
  - It passes environment variables at VM startup, so supporting both WASI Preview 1 and WASI Preview 2 is appropriate.
  - There is no particular reason to exclude WASI Preview 2 from `data-env` support.
  - The integration test confirms that environment variables are also passed on WASI Preview 2.
- `Ruby::Box` example:
  - It is a useful practical data-env example because `Ruby::Box` requires `RUBY_BOX=1` at VM startup.
  - `Ruby::Box`'s require hook copies extension libraries to `/tmp` before loading them.
  - This works with the WASI Preview 1 browser shim.
  - The WASI Preview 2 browser component setup does not currently initialize writable `/tmp`, so the `Ruby::Box` example does not work there yet.
- CI behavior:
  - Ruby 3.x is skipped because `Ruby::Box` is not available there.
  - Ruby 4.0+ / head with WASI Preview 2 is also skipped because writable /`tmp` is not currently provided.
- Future work:
  - To make `Ruby::Box` work on WASI Preview 2, the Preview 2 browser filesystem needs a writable preopen equivalent to `/tmp`.
  - That is outside the scope of this `data-env` PR.

