### PR TITLE
Update ruby-head WASI gem lockfile

### DIFF
--- a/packages/npm-packages/ruby-head-wasm-wasi/Gemfile.lock
+++ b/packages/npm-packages/ruby-head-wasm-wasi/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: ../../..
   specs:
-    ruby_wasm (2.8.1.dev)
+    ruby_wasm (2.10.1)
       logger
 
 GEM
   remote: https://rubygems.org/
   specs:
-    js (2.8.1.dev)
+    js (2.10.1)
     logger (1.7.0)
     power_assert (2.0.3)
     test-unit (3.6.2)
@@ -18,7 +18,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  js (= 2.8.1.dev)
+  js (= 2.10.1)
   power_assert
   ruby_wasm!
   test-unit


### PR DESCRIPTION
## Summary

- update the ruby_wasm lockfile entry from 2.8.1.dev to 2.10.1
- update the js lockfile entry and dependency constraint to 2.10.1
- prevent bundle install during ruby-head-wasm-wasi builds from rewriting Gemfile.lock

## Background

The last commit that updated packages/npm-packages/ruby-head-wasm-wasi/Gemfile.lock was cc57b30d (rake bump_dev_version), which changed its ruby_wasm and js entries from 2.8.0 to 2.8.1.dev.

This appears to be a repeated release-version update omission rather than a one-time mismatch. The bump_version task runs bundle install for every entry in NPM_PACKAGES that has a Gemfile, and ruby-head-wasm-wasi is explicitly one of those entries. However, each of the following release commits updated the project versions and the equivalent ruby-head-wasm-wasip2 lockfile while leaving ruby-head-wasm-wasi/Gemfile.lock unchanged:

- ae47c499: Release 2.9.0
- 246106de: Release 2.9.3
- d3089aa2: Release 2.9.4
- f1c909b9: Release 2.10.0
- cbb1e844: Release 2.10.1

As a result, the head WASI lockfile remained at 2.8.1.dev across all five releases. This PR aligns it directly with the current 2.10.1 versions.

