### PR TITLE
Expose WASI preopens through DefaultRubyVM

### DIFF
--- a/packages/npm-packages/ruby-wasm-wasi/example/README.md
+++ b/packages/npm-packages/ruby-wasm-wasi/example/README.md
@@ -17,4 +17,5 @@ $ # Open http://localhost:8000/script-src
 ```console
 $ npm install
 $ node index.node.js
+$ node preopens.node.js
 ```

--- a/packages/npm-packages/ruby-wasm-wasi/example/preopens.node.js
+++ b/packages/npm-packages/ruby-wasm-wasi/example/preopens.node.js
@@ -1,0 +1,17 @@
+import fs from "fs/promises";
+import { DefaultRubyVM } from "@ruby/wasm-wasi/dist/node";
+
+// $ node preopens.node.js
+
+const binary = await fs.readFile(
+  "./node_modules/@ruby/head-wasm-wasi/dist/ruby.wasm",
+);
+const module = await WebAssembly.compile(binary);
+const { vm } = await DefaultRubyVM(module, {
+  preopens: {
+    "/app": "./require_relative",
+  },
+});
+
+// /app/main.rb uses require_relative to load /app/greeting.rb.
+vm.eval('require "/app/main"');

--- a/packages/npm-packages/ruby-wasm-wasi/src/node.ts
+++ b/packages/npm-packages/ruby-wasm-wasi/src/node.ts
@@ -3,9 +3,17 @@ import { RubyVM } from "./vm.js";
 
 export const DefaultRubyVM = async (
   rubyModule: WebAssembly.Module,
-  options: { env?: Record<string, string> | undefined } = {},
+  options: {
+    env?: Record<string, string> | undefined;
+    preopens?: Record<string, string>;
+  } = {},
 ) => {
-  const wasi = new WASI({ env: options.env, version: "preview1", returnOnExit: true });
+  const wasi = new WASI({
+    env: options.env,
+    preopens: options.preopens,
+    version: "preview1",
+    returnOnExit: true,
+  });
   const { vm, instance } = await RubyVM.instantiateModule({ module: rubyModule, wasip1: wasi });
 
   return {

--- a/packages/npm-packages/ruby-wasm-wasi/test/package.test.js
+++ b/packages/npm-packages/ruby-wasm-wasi/test/package.test.js
@@ -1,5 +1,6 @@
 import * as path from "path";
 import * as fs from "fs/promises";
+import * as os from "os";
 import { WASI } from "wasi";
 import { RubyVM } from "../src/index";
 import { DefaultRubyVM } from "../src/node";
@@ -57,6 +58,52 @@ describe("Packaging validation", () => {
     const mod = await loadWasmModule(`ruby+stdlib.wasm`);
     const { vm } = await DefaultRubyVM(mod);
     vm.eval(`require "stringio"`);
+  });
+
+  test("DefaultRubyVM WASI preopens with require_relative", async () => {
+    const mod = await loadWasmModule(`ruby+stdlib.wasm`);
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ruby-wasm-preopen-"));
+    const nestedDir = path.join(tempDir, "nested");
+    const entryFile = path.join(tempDir, "entry.rb");
+    const helperFile = path.join(nestedDir, "helper.rb");
+
+    try {
+      await fs.mkdir(nestedDir);
+      await fs.writeFile(entryFile, [
+        "PREOPEN_ENTRY_FILE = __FILE__",
+        "require_relative './nested/helper'",
+      ].join("\n"));
+      await fs.writeFile(helperFile, "PREOPEN_HELPER_FILE = __FILE__\n");
+
+      const { vm } = await DefaultRubyVM(mod, {
+        preopens: { "/app": tempDir },
+      });
+      expect(vm.eval(`require "/app/entry"`).toString()).toBe("true");
+      expect(vm.eval(`require "/app/entry"`).toString()).toBe("false");
+
+      expect(vm.eval("PREOPEN_ENTRY_FILE").toString()).toBe("/app/entry.rb");
+      expect(vm.eval("PREOPEN_HELPER_FILE").toString()).toBe(
+        "/app/nested/helper.rb",
+      );
+      expect(
+        vm.eval('$LOADED_FEATURES.include?("/app/entry.rb")').toString(),
+      ).toBe("true");
+      expect(
+        vm
+          .eval('$LOADED_FEATURES.include?("/app/nested/helper.rb")')
+          .toString(),
+      ).toBe("true");
+      expect(
+        vm
+          .eval(`$LOADED_FEATURES.include?(${JSON.stringify(entryFile)})`)
+          .toString(),
+      ).toBe("false");
+      expect(vm.eval(`File.file?(${JSON.stringify(entryFile)})`).toString()).toBe(
+        "false",
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   test.each([


### PR DESCRIPTION
## Motivation

As we develop the JavaScript APIs for running Ruby, Node.js is a convenient environment for quickly verifying behavior. However, `DefaultRubyVM` did not expose the WASI `preopens` option, so loading an application made up of multiple local Ruby files was unnecessarily difficult.

The goal of this PR is to make local Ruby application code easy to load in Node.js while keeping the normal Ruby loading behavior.

## Why WASI preopens

One possible approach is a loader similar to `RequireRemote`: read source code through JavaScript and evaluate it in Ruby. For local files in Node.js, WASI preopens provide a better fit:

- Ruby can use its native `require` and `require_relative` implementations.
- Ruby itself manages path resolution, `$LOADED_FEATURES`, duplicate requires, and load errors.
- Only explicitly preopened host directories are visible inside the WASI guest namespace; this does not expose unrestricted Node.js filesystem access to Ruby.
- It avoids introducing and maintaining another Ruby/JavaScript loader and filesystem bridge.

`RequireRemote` remains useful in browser environments where source files must be fetched over a URL. This PR uses the WASI filesystem capability already available in Node.js for the local-file case.

## Changes

- expose Node.js WASI `preopens` through `DefaultRubyVM`
- add a Node.js example that preopens a directory and loads local Ruby files using `require` and `require_relative`
- verify guest paths in `__FILE__` and `$LOADED_FEATURES`, duplicate-require behavior, and that the original host path is not visible to Ruby

## Example

```js
const { vm } = await DefaultRubyVM(module, {
  preopens: {
    "/app": "./require_relative",
  },
});

vm.eval(`require "/app/main"`);
```

## Verification

- `bundle exec rake npm:ruby-wasm-wasi:build`
- `env RUBY_NPM_PACKAGE_ROOT=packages/npm-packages/ruby-head-wasm-wasi npm run test:vitest --workspace=@ruby/wasm-wasi -- --run` (44 tests)
- `node packages/npm-packages/ruby-wasm-wasi/example/preopens.node.js`
- `git diff --check origin/main...HEAD`