### PR TITLE
Test the preopens Node.js example

### DIFF
--- a/packages/npm-packages/ruby-wasm-wasi/example/preopens.node.js
+++ b/packages/npm-packages/ruby-wasm-wasi/example/preopens.node.js
@@ -15,3 +15,4 @@ const { vm } = await DefaultRubyVM(module, {
 
 // /app/main.rb uses require_relative to load /app/greeting.rb.
 vm.eval('require "/app/main"');
+vm.eval("$stdout.flush");

--- a/packages/npm-packages/ruby-wasm-wasi/test-node-examples/examples.test.js
+++ b/packages/npm-packages/ruby-wasm-wasi/test-node-examples/examples.test.js
@@ -21,6 +21,8 @@ describe("Node.js examples", () => {
   }, 70_000);
 
   test("preopens.node.js is healthy", async () => {
-    await context.run("preopens.node.js");
+    const { stdout } = await context.run("preopens.node.js");
+
+    expect(stdout).toBe("Hello, world!\n");
   }, 70_000);
 });

--- a/packages/npm-packages/ruby-wasm-wasi/test-node-examples/examples.test.js
+++ b/packages/npm-packages/ruby-wasm-wasi/test-node-examples/examples.test.js
@@ -19,4 +19,8 @@ describe("Node.js examples", () => {
     expect(stdout).toContain("NoMethodError");
     expect(stdout).toContain("RuntimeError");
   }, 70_000);
+
+  test("preopens.node.js is healthy", async () => {
+    await context.run("preopens.node.js");
+  }, 70_000);
 });

--- a/packages/npm-packages/ruby-wasm-wasi/test-node-examples/support.js
+++ b/packages/npm-packages/ruby-wasm-wasi/test-node-examples/support.js
@@ -21,10 +21,16 @@ export const setupNodeExampleTest = async () => {
     temporaryDir,
     "node_modules/@ruby/head-wasm-wasi",
   );
+  const requireRelativeLink = path.join(temporaryDir, "require_relative");
 
   try {
     await fs.mkdir(path.dirname(packageLink), { recursive: true });
     await fs.symlink(rubyPackageRoot, packageLink, "dir");
+    await fs.symlink(
+      path.join(exampleDir, "require_relative"),
+      requireRelativeLink,
+      "dir",
+    );
   } catch (error) {
     await fs.rm(temporaryDir, { recursive: true, force: true });
     throw error;


### PR DESCRIPTION

Run `preopens.node.js` in Node's example smoke test.
Assert that “Hello, world!” is printed to standard output.