### PR TITLE
build(deps): update wit-component to 0.244

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1681,7 +1681,7 @@ dependencies = [
  "wasi-vfs-cli",
  "wasi-virt",
  "wasm-compose 0.219.2",
- "wit-component 0.216.1",
+ "wit-component 0.244.0",
 ]
 
 [[package]]
@@ -2493,16 +2493,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.216.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1de2d0fd411c201b8d76c04213901f9bb221abf17dd59c2201542d0b118bb90"
-dependencies = [
- "leb128",
- "wasmparser 0.216.1",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.219.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aa79bcd666a043b58f5fa62b221b0b914dd901e6f620e8ab7371057a797f3e1"
@@ -2559,22 +2549,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.216.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9083c392e884fe09563038ffbaeef6a367fe00df808f0f4ddde2b6e790af461"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "serde",
- "serde_derive",
- "serde_json",
- "spdx",
- "wasm-encoder 0.216.1",
- "wasmparser 0.216.1",
-]
-
-[[package]]
-name = "wasm-metadata"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
@@ -2596,19 +2570,6 @@ name = "wasmparser"
 version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d28bc49ba1e5c5b61ffa7a2eace10820443c4b7d1c0b144109261d14570fdf8"
-dependencies = [
- "ahash",
- "bitflags 2.11.0",
- "hashbrown 0.14.5",
- "indexmap 2.14.0",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.216.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc7c63191ae61c70befbe6045b9be65ef2082fa89421a386ae172cb1e08e92d"
 dependencies = [
  "ahash",
  "bitflags 2.11.0",
@@ -3352,25 +3313,6 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.216.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a48c42cb814ed4d7fd7163d5d898ce1197569332337d3e6033ca3272e732f77d"
-dependencies = [
- "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.216.1",
- "wasm-metadata 0.216.1",
- "wasmparser 0.216.1",
- "wit-parser 0.216.1",
-]
-
-[[package]]
-name = "wit-component"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
@@ -3404,24 +3346,6 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.212.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.216.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01dbe6d583f32e9ff8309350112b6e4baa883486355476793bb719b15e5c971e"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.216.1",
 ]
 
 [[package]]

--- a/ext/ruby_wasm/Cargo.toml
+++ b/ext/ruby_wasm/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 magnus = { version = "0.8", features = ["bytes"] }
 bytes = "1"
 structopt = "0.3.26"
-wit-component = "0.216.0"
+wit-component = "0.244.0"
 wasm-compose = "0.219.1"
 wasi-virt = { git = "https://github.com/bytecodealliance/wasi-virt", rev = "dadd131d8cf8ed1ed4265e96350f5f166e27a339", default-features = false }
 wasi-vfs-cli = { git = "https://github.com/kateinoigakukun/wasi-vfs/", tag = "v0.6.2" }

--- a/ext/ruby_wasm/src/lib.rs
+++ b/ext/ruby_wasm/src/lib.rs
@@ -169,7 +169,7 @@ impl ComponentEncode {
 
     fn encode(&self) -> Result<bytes::Bytes, Error> {
         // Take the encoder out of the cell and consume it
-        let encoder = self
+        let mut encoder = self
             .0
             .borrow_mut()
             .take()


### PR DESCRIPTION
This updates only the direct `wit-component` dependency from 0.216 to 0.244, separately from #644. `wasm-compose` and `wasi-vfs-cli` remain unchanged so CI can show whether the `wit-component` update is independently compatible.

`ComponentEncoder::encode` now requires `&mut self`, so declare the local encoder binding as mutable.

Local verification:

- `cargo check -p ruby_wasm --locked`
- `cargo fmt --all -- --check`
- `git diff --check`