### PR TITLE
build(deps): bump @rollup/plugin-typescript to 12.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1145,10 +1145,11 @@
             }
         },
         "node_modules/@rollup/plugin-typescript": {
-            "version": "12.1.4",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-12.1.4.tgz",
-            "integrity": "sha512-s5Hx+EtN60LMlDBvl5f04bEiFZmAepk27Q+mr85L/00zPDn1jtzlTV6FWn81MaIwqfWzKxmOJrBWHU6vtQyedQ==",
+            "version": "12.3.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-12.3.0.tgz",
+            "integrity": "sha512-7DP0/p7y3t67+NabT9f8oTBFE6gGkto4SA6Np2oudYmZE/m1dt8RB0SjL1msMxFpLo631qjRCcBlAbq1ml/Big==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@rollup/pluginutils": "^5.1.0",
                 "resolve": "^1.22.1"
@@ -3656,7 +3657,7 @@
             },
             "devDependencies": {
                 "@bytecodealliance/jco": "1.8.1",
-                "@rollup/plugin-typescript": "^12.1.4",
+                "@rollup/plugin-typescript": "^12.3.0",
                 "@types/node": "24.1.0",
                 "prettier": "^3.6.2",
                 "typescript": "^5.9.2",

--- a/packages/npm-packages/ruby-wasm-wasi/package.json
+++ b/packages/npm-packages/ruby-wasm-wasi/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@bytecodealliance/jco": "1.8.1",
-    "@rollup/plugin-typescript": "^12.1.4",
+    "@rollup/plugin-typescript": "^12.3.0",
     "@types/node": "24.1.0",
     "prettier": "^3.6.2",
     "typescript": "^5.9.2",

--- a/packages/npm-packages/ruby-wasm-wasi/rollup.config.mjs
+++ b/packages/npm-packages/ruby-wasm-wasi/rollup.config.mjs
@@ -1,7 +1,11 @@
 import typescript from "@rollup/plugin-typescript";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 
-const typescriptOptions = { tsconfig: "./tsconfig.json", declaration: false };
+const typescriptOptions = {
+  tsconfig: "./tsconfig.json",
+  declaration: false,
+  outDir: "./dist",
+};
 
 function config({ basename }) {
   return {


### PR DESCRIPTION
## Summary

- bump only `@rollup/plugin-typescript` from 12.1.4 to 12.3.0
- set the Rollup TypeScript `outDir` explicitly to keep generated files under `dist`
- separate and resolve the `@rollup/plugin-typescript` blocker before #614 can proceed

## Background

Version 12.3.0 creates a temporary TypeScript `outDir` when `allowJs` is enabled. Its path validation then rejects that temporary directory because the Rollup `file` outputs are under `dist`. Explicitly setting the plugin's `outDir` to `./dist` keeps the output paths compatible.

## Verification

```console
bundle exec rake npm:ruby-wasm-wasi:build
```

The Rollup UMD outputs and the subsequent ESM/CJS TypeScript builds complete successfully.