### PR TITLE
build(deps): bump TypeScript to 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3659,7 +3659,7 @@
                 "@rollup/plugin-typescript": "^12.1.4",
                 "@types/node": "24.1.0",
                 "prettier": "^3.6.2",
-                "typescript": "^5.9.2",
+                "typescript": "^6.0.3",
                 "vitest": "^3.2.4"
             }
         },
@@ -3700,9 +3700,9 @@
             }
         },
         "packages/npm-packages/ruby-wasm-wasi/node_modules/typescript": {
-            "version": "5.9.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-            "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/packages/npm-packages/ruby-wasm-wasi/package.json
+++ b/packages/npm-packages/ruby-wasm-wasi/package.json
@@ -58,7 +58,7 @@
     "@rollup/plugin-typescript": "^12.1.4",
     "@types/node": "24.1.0",
     "prettier": "^3.6.2",
-    "typescript": "^5.9.2",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.4"
   },
   "dependencies": {

--- a/packages/npm-packages/ruby-wasm-wasi/rollup.config.mjs
+++ b/packages/npm-packages/ruby-wasm-wasi/rollup.config.mjs
@@ -1,7 +1,11 @@
 import typescript from "@rollup/plugin-typescript";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 
-const typescriptOptions = { tsconfig: "./tsconfig.json", declaration: false };
+const typescriptOptions = {
+  tsconfig: "./tsconfig.json",
+  declaration: false,
+  ignoreDeprecations: "5.0",
+};
 
 function config({ basename }) {
   return {

--- a/packages/npm-packages/ruby-wasm-wasi/tsconfig.json
+++ b/packages/npm-packages/ruby-wasm-wasi/tsconfig.json
@@ -1,12 +1,17 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "strict": false,
+    "skipLibCheck": true,
     "importHelpers": true,
     "allowJs": true,
+    "rootDir": "./src",
     "module": "ES2015",
     "target": "es2017",
     "esModuleInterop": true,
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
+    "types": ["node"],
     "resolveJsonModule": true
   },
   "include": ["src/**/*.ts", "./src/bindgen/**/*"],


### PR DESCRIPTION
## Summary

- bump only TypeScript from 5.9.2 to 6.0.3
- make the existing compiler behavior explicit for TypeScript 6
- separate and resolve the TypeScript blocker before #614 can proceed

## Compatibility changes

- set `rootDir` explicitly as required by TypeScript 6
- preserve the previous non-strict behavior and Node type inclusion
- suppress the `moduleResolution=node10` deprecation while retaining the current module resolution semantics
- skip conflicts between TypeScript 6 built-in declarations and external Node declarations
- use a TypeScript 5-compatible deprecation setting for Rollup, whose plugin resolves the repository-root TypeScript version

## Verification

```console
bundle exec rake npm:ruby-wasm-wasi:build
```

The Rollup UMD outputs and the subsequent ESM/CJS TypeScript builds complete successfully.