### PR TITLE
Key wasi-sysroot build flags on the toolchain instead of the target triple

### DIFF
--- a/lib/ruby_wasm/build/product/crossruby.rb
+++ b/lib/ruby_wasm/build/product/crossruby.rb
@@ -344,8 +344,7 @@ module RubyWasm
       # target-side wasm dump_ast while generating .rbinc files.
       args << %Q(--with-dump-ast=#{dump_ast_path})
 
-      case target
-      when /^wasm32-unknown-wasi/
+      if @toolchain.wasi_sysroot?
         xldflags << @wasi_vfs.lib_wasi_vfs_a if @wasi_vfs
         # TODO: Find a way to force cast or update API
         # @type var wasi_sdk_path: untyped
@@ -363,6 +362,9 @@ module RubyWasm
         # it broke Kernel#require on @bjorn3/browser_wasi_shim setup for some
         # reason. So we disable it for now.
         args << %Q(ac_cv_func_realpath=no)
+      end
+
+      case target
       when "wasm32-unknown-emscripten"
         ldflags.concat(%w[-s MODULARIZE=1])
         env_emcc_ldflags = ENV["RUBY_WASM_EMCC_LDFLAGS"] || ""
@@ -370,7 +372,7 @@ module RubyWasm
           ldflags << env_emcc_ldflags
         end
       else
-        raise "unknown target: #{target}"
+        raise "unknown target: #{target}" unless @toolchain.wasi_sysroot?
       end
 
       args.concat(self.tools_args)

--- a/lib/ruby_wasm/build/product/openssl.rb
+++ b/lib/ruby_wasm/build/product/openssl.rb
@@ -42,7 +42,7 @@ module RubyWasm
         --libdir=lib
         -Wl,--allow-undefined
       ]
-      if @target.triple.start_with?("wasm32-unknown-wasi")
+      if @toolchain.wasi_sysroot?
         args.concat %w[
                       -D_WASI_EMULATED_SIGNAL
                       -D_WASI_EMULATED_PROCESS_CLOCKS

--- a/lib/ruby_wasm/build/toolchain.rb
+++ b/lib/ruby_wasm/build/toolchain.rb
@@ -8,6 +8,12 @@ module RubyWasm
       @tools = {}
     end
 
+    # If this toolchain compiles against wasi-libc, it needs
+    # wasi-libc's emulation feature flags.
+    def wasi_sysroot?
+      false
+    end
+
     def find_tool(name)
       raise "not implemented"
     end
@@ -88,6 +94,10 @@ module RubyWasm
       }
       @wasi_sdk_path = wasi_sdk_path
       @name = "wasi-sdk"
+    end
+
+    def wasi_sysroot?
+      true
     end
 
     def find_tool(name)

--- a/sig/ruby_wasm/build.rbs
+++ b/sig/ruby_wasm/build.rbs
@@ -251,6 +251,7 @@ module RubyWasm
     def ar: -> String
 
     def install: (_CommandExecutor executor) -> void
+    def wasi_sysroot?: -> bool
   end
 
   class WASISDK < Toolchain
@@ -268,6 +269,7 @@ module RubyWasm
     def download_url: () -> String
     def install_wasi_sdk: (_CommandExecutor executor) -> void
     def install: (_CommandExecutor executor) -> void
+    def wasi_sysroot?: -> bool
   end
 
   class Binaryen

--- a/test/toolchain_predicate_test.rb
+++ b/test/toolchain_predicate_test.rb
@@ -1,0 +1,17 @@
+require "test-unit"
+require_relative "../lib/ruby_wasm/build/toolchain"
+# require "bundler"
+
+class ToolchainPredicateTest < Test::Unit::TestCase
+  def test_base_toolchain_is_not_wasi_sysroot
+    assert_equal false, Class.new(RubyWasm::Toolchain).allocate.wasi_sysroot?
+  end
+
+  def test_wasi_sdk_is_wasi_sysroot
+    assert_equal true, Class.new(RubyWasm::WASISDK).allocate.wasi_sysroot?
+  end
+
+  def test_emscripten_is_not_wasi_sysroot
+    assert_equal false, Class.new(RubyWasm::Emscripten).allocate.wasi_sysroot?
+  end
+end


### PR DESCRIPTION
<h2>Summary</h2>
<p>Note: This bug report and fix is AI-assisted</p>
<p>Several build products decide whether to pass wasi-libc's emulation flags by testing the target triple string against <code>wasm32-unknown-wasi</code>. Those flags exist because the code is being compiled against wasi-sysroot, a property of the toolchain, not the target.</p> 
<p>This means that a target using <code>RubyWasm::WASISDK</code> with triple other than <code>wasm32-unknown-wasi*</code> is configured with the wasi-sdk compiler but fails to build without the flags, with an unhelpful failure message.</p>
<p>This PR adds a <code>wasi_sysroot?</code> predicate to <code>RubyWasm::Toolchain</code>, returning <code>false</code> by default and <code>true</code> on <code>WASISDK</code>, and switches the sysroot-driven sites to test it.</p> <h2>The bug</h2> <p><code>lib/ruby_wasm/build/product/openssl.rb:45</code></p> <pre><code class="language-ruby">if @target.triple.start_with?("wasm32-unknown-wasi") </code></pre> <p>A wasi-sdk target failing this test gets none of <code>-D_WASI_EMULATED_SIGNAL</code>, <code>-D_WASI_EMULATED_PROCESS_CLOCKS</code>, <code>-D_WASI_EMULATED_MMAN</code>, <code>-D_WASI_EMULATED_GETPID</code>, <code>-DNO_CHMOD</code> or <code>-DHAVE_FORK=0</code>. OpenSSL then fails on wasi-libc's <code>signal.h</code>:</p> <pre><code>error: "wasm lacks signal support; to enable minimal signal emulation, compile with -D_WASI_EMULATED_SIGNAL and link with -lwasi-emulated-signal"
</code></pre>

<p><code>lib/ruby_wasm/build/product/crossruby.rb:349</code> has the same gate, carrying
<code>WASMOPT</code>, <code>WASI_SDK_PATH</code>, <code>ac_cv_func_fchmod=no</code>, <code>ac_cv_func_chmod=no</code> and
<code>ac_cv_func_realpath=no</code>. CRuby's own configure hits the equivalent wall
immediately after OpenSSL is cleared.</p>
<p>The base array in <code>openssl.rb</code> already carries <code>-no-sock</code>, <code>-no-dgram</code>,
<code>-no-threads</code> and <code>-Wl,--allow-undefined</code> unconditionally, so a failing build
looks partly wasm-aware. That makes this harder to spot than it should be — the build appears to know it is targeting wasm, and fails anyway.</p>

<h2>Changes</h2>
<ol>
<li><code>Toolchain#wasi_sysroot?</code> returning <code>false</code>; <code>WASISDK#wasi_sysroot?</code>
returning <code>true</code>. Subclasses of <code>WASISDK</code> inherit the correct answer.</li>
<li><code>openssl.rb</code> and <code>crossruby.rb</code> test the predicate instead of the triple
prefix. In <code>crossruby.rb</code> the sysroot block is hoisted out of the <code>case</code>,
leaving the <code>case</code> for genuinely target-specific concerns. Its <code>else</code> arm
still raises on an unknown target, but now defers to the predicate rather
than to a triple prefix, so a wasi-sdk target is not rejected by the guard
after the block above has already handled it.</li>
<li>RBS signatures for both predicate definitions.</li>
<li>Unit tests asserting the predicate on <code>Toolchain</code>, <code>WASISDK</code> and
<code>Emscripten</code>.</li>
</ol>
<h2>Sites deliberately not changed</h2>
<ul>
<li><code>toolchain.rb:29</code> dispatches triple to toolchain and cannot be predicate
driven without circularity.</li>
<li><code>packager.rb:47</code> gates the wasip1 component adapter, which is genuinely
specific to that triple.</li>
<li><code>packager.rb:100</code>, <code>cli.rb:52</code> are defaults.</li>
<li><code>wasi_vfs.rb:15</code> is a hardcoded build target for the wasi-vfs crate.</li>
</ul>
<p>The test applied at each site: is this here because of the sysroot, or
because of the target's identity? Only the former became the predicate.</p>
<h2>Naming</h2>
<p><code>wasi_sysroot?</code> names the actual reason the flags exist. <code>wasi?</code> was avoided
deliberately: that ambiguity is what caused the bug, since a target can
compile against wasi-sysroot without being wasip1.</p>
<h2>Testing</h2>
<p>Built <code>3.3-wasm32-unknown-wasip1-full</code> on <code>upstream/main</code> and on this branch.
Both artifacts are byte-identical:</p>

Artifact | upstream/main | This branch
-- | -- | --
ruby | 49135b1095a5a61cea452e4f2e34d42efcd3f5831fca4a4e04f205a458db7720 | 49135b1095a5a61cea452e4f2e34d42efcd3f5831fca4a4e04f205a458db7720
libruby-static.a | 7a79f61e8c03edba48cbde3586a1668eeb7f814146825798b952bd633ff1db15 | 7a79f61e8c03edba48cbde3586a1668eeb7f814146825798b952bd633ff1db15


<p><code>full</code> rather than <code>minimal</code> because <code>build.rb:53</code> constructs
<code>OpenSSLProduct</code> unconditionally, so <code>full</code> exercises the OpenSSL gate that
<code>minimal</code> may not reach.</p>
<p>That result is what the change predicts, because the predicate returns the
same answer as the triple test for every target that exists today:</p>
<ul>
<li><strong>wasip1</strong> — triple starts <code>wasm32-unknown-wasi</code>, so the old gate is true;
<code>WASISDK#wasi_sysroot?</code> is true. No change.</li>
<li><strong>emscripten</strong> — old gate false; <code>Emscripten</code> descends from <code>Toolchain</code>,
not <code>WASISDK</code>, so the predicate is false. No change.</li>
</ul>
<p>Both cases are covered by unit tests on the predicate itself. The emscripten
case is asserted by test but not by a build — worth flagging rather than
leaving for someone to notice.</p>
<p><code>steep check</code> is clean.</p>
<h2>Provenance</h2>
<p>Found while adding a wasi-sdk target for the Internet Computer (#653). The
bug is not specific to that target: it bites any new <code>WASISDK</code> subclass whose
triple is not named <code>wasm32-unknown-wasi*</code>, and it is worth fixing whether or
not ruby.wasm decides to support an ICP target.</p></body></html>